### PR TITLE
Add exchange session intelligence for US/HK/CN

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -92,6 +92,7 @@ from prediction_market_analysis import (
     analyze_prediction_market as pm_analyze_market,
 )
 import akshare_service
+import exchange_session_service
 import sec_filings_service
 from asset_identity import parse_asset_reference
 from logger_config import setup_logger, log_api_error
@@ -1354,6 +1355,7 @@ def get_stock_data(ticker):
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
+        exchange_session_service_module=exchange_session_service,
     )
 
 
@@ -1990,6 +1992,7 @@ def get_fundamentals(ticker):
         fundamentals_from_yfinance_fn=_fundamentals_from_yfinance,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
+        exchange_session_service_module=exchange_session_service,
     )
 # --- NEW: Autocomplete Symbol Search (from Jimmy's branch) ---
 @app.route('/search-symbols')
@@ -2019,6 +2022,16 @@ def get_economic_calendar():
         jsonify_fn=jsonify,
         time_module=time,
         datetime_cls=datetime,
+    )
+
+
+@app.route('/calendar/market-sessions', methods=['GET'])
+def get_market_sessions_calendar():
+    return reference_data_handlers.get_market_sessions_handler(
+        request_obj=request,
+        jsonify_fn=jsonify,
+        logger=logger,
+        exchange_session_service_module=exchange_session_service,
     )
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2166,6 +2179,7 @@ def public_api_stock(ticker):
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
+        exchange_session_service_module=exchange_session_service,
     )
 
 
@@ -2280,6 +2294,7 @@ def public_api_fundamentals(ticker):
         fundamentals_from_yfinance_fn=_fundamentals_from_yfinance,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
+        exchange_session_service_module=exchange_session_service,
     )
 
 
@@ -2357,6 +2372,7 @@ def public_api_v2_stock(ticker):
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
+        exchange_session_service_module=exchange_session_service,
     )
 
 
@@ -2405,6 +2421,7 @@ def public_api_v2_fundamentals(ticker):
         fundamentals_from_yfinance_fn=_fundamentals_from_yfinance,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
+        exchange_session_service_module=exchange_session_service,
     )
 
 

--- a/backend/api_handlers_market_data.py
+++ b/backend/api_handlers_market_data.py
@@ -49,13 +49,19 @@ def get_stock_data_handler(
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
+    exchange_session_service_module,
 ):
     try:
         market = request_obj.args.get("market")
         asset = resolve_asset_fn(ticker, market)
         if asset["market"] in {"HK", "CN"}:
             try:
-                return jsonify_fn(akshare_service_module.get_equity_snapshot(asset["assetId"]))
+                snapshot = dict(akshare_service_module.get_equity_snapshot(asset["assetId"]))
+                snapshot["marketSession"] = exchange_session_service_module.get_market_session(
+                    asset["market"],
+                    exchange=snapshot.get("exchange") or asset["exchange"],
+                )
+                return jsonify_fn(snapshot)
             except akshare_service_module.AkshareUnavailableError as exc:
                 return jsonify_fn({"error": str(exc)}), 503
             except akshare_service_module.AkshareAssetNotFoundError as exc:
@@ -168,6 +174,10 @@ def get_stock_data_handler(
             "fundamentals": fundamentals,
             "financials": financials,
         }
+        formatted_data["marketSession"] = exchange_session_service_module.get_market_session(
+            asset["market"],
+            exchange=formatted_data.get("exchange") or asset["exchange"],
+        )
         return jsonify_fn(formatted_data)
     except Exception as exc:
         return jsonify_fn({"error": f"An error occurred: {str(exc)}"}), 500

--- a/backend/api_handlers_public.py
+++ b/backend/api_handlers_public.py
@@ -94,6 +94,7 @@ def stock_handler(
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
+    exchange_session_service_module,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -108,6 +109,7 @@ def stock_handler(
                 clean_value_fn=clean_value_fn,
                 resolve_asset_fn=resolve_asset_fn,
                 akshare_service_module=akshare_service_module,
+                exchange_session_service_module=exchange_session_service_module,
             )
         )
         if status_code == 404:
@@ -150,6 +152,7 @@ def stock_handler_v2(
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
+    exchange_session_service_module,
 ):
     def producer():
         asset = _public_asset_identity(ticker=ticker, request_obj=request_obj, resolve_asset_fn=resolve_asset_fn)
@@ -165,6 +168,7 @@ def stock_handler_v2(
                 clean_value_fn=clean_value_fn,
                 resolve_asset_fn=resolve_asset_fn,
                 akshare_service_module=akshare_service_module,
+                exchange_session_service_module=exchange_session_service_module,
             )
         )
         if status_code == 404:
@@ -499,6 +503,7 @@ def fundamentals_handler(
     fundamentals_from_yfinance_fn,
     resolve_asset_fn,
     akshare_service_module,
+    exchange_session_service_module,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -513,13 +518,16 @@ def fundamentals_handler(
                 fundamentals_from_yfinance_fn=fundamentals_from_yfinance_fn,
                 resolve_asset_fn=resolve_asset_fn,
                 akshare_service_module=akshare_service_module,
+                exchange_session_service_module=exchange_session_service_module,
             )
         )
         if status_code == 404:
             raise PublicApiError(404, "invalid_ticker", f"Ticker '{ticker}' is invalid or unavailable.")
         if status_code >= 500:
             raise PublicApiError(503, "upstream_unavailable", "Fundamental data is temporarily unavailable.")
-        return (dict(raw_payload or {}), 200)
+        payload = dict(raw_payload or {})
+        payload.pop("marketSession", None)
+        return (payload, 200)
 
     return _cached_json_payload(
         cache_backend=cache_backend,
@@ -544,6 +552,7 @@ def fundamentals_handler_v2(
     fundamentals_from_yfinance_fn,
     resolve_asset_fn,
     akshare_service_module,
+    exchange_session_service_module,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -558,13 +567,16 @@ def fundamentals_handler_v2(
                 fundamentals_from_yfinance_fn=fundamentals_from_yfinance_fn,
                 resolve_asset_fn=resolve_asset_fn,
                 akshare_service_module=akshare_service_module,
+                exchange_session_service_module=exchange_session_service_module,
             )
         )
         if status_code == 404:
             raise PublicApiError(404, "invalid_ticker", f"Ticker '{ticker}' is invalid or unavailable.")
         if status_code >= 500:
             raise PublicApiError(503, "upstream_unavailable", "Fundamental data is temporarily unavailable.")
-        return (dict(raw_payload or {}), 200)
+        payload = dict(raw_payload or {})
+        payload.pop("marketSession", None)
+        return (payload, 200)
 
     return _cached_json_payload(
         cache_backend=cache_backend,

--- a/backend/api_handlers_reference_data.py
+++ b/backend/api_handlers_reference_data.py
@@ -104,13 +104,19 @@ def get_fundamentals_handler(
     fundamentals_from_yfinance_fn,
     resolve_asset_fn,
     akshare_service_module,
+    exchange_session_service_module,
 ):
     try:
         market = request_obj.args.get("market")
         asset = resolve_asset_fn(ticker, market)
         if asset["market"] in {"HK", "CN"}:
             try:
-                return jsonify_fn(akshare_service_module.get_equity_fundamentals(asset["assetId"]))
+                payload = dict(akshare_service_module.get_equity_fundamentals(asset["assetId"]))
+                payload["marketSession"] = exchange_session_service_module.get_market_session(
+                    asset["market"],
+                    exchange=payload.get("exchange") or asset["exchange"],
+                )
+                return jsonify_fn(payload)
             except akshare_service_module.AkshareUnavailableError as exc:
                 return jsonify_fn({"error": str(exc)}), 503
             except akshare_service_module.AkshareAssetNotFoundError as exc:
@@ -137,6 +143,13 @@ def get_fundamentals_handler(
         else:
             yf_data = fundamentals_from_yfinance_fn(sanitized_ticker)
             if yf_data:
+                yf_data = dict(yf_data)
+                yf_data.setdefault("assetId", asset["assetId"])
+                yf_data.setdefault("market", asset["market"])
+                yf_data["marketSession"] = exchange_session_service_module.get_market_session(
+                    asset["market"],
+                    exchange=yf_data.get("exchange") or asset.get("exchange"),
+                )
                 return jsonify_fn(yf_data)
             return jsonify_fn({"error": f"No fundamental data found for {ticker}"}), 404
 
@@ -184,6 +197,10 @@ def get_fundamentals_handler(
             "day_200_moving_average": clean_value_fn(data.get("200DayMovingAverage")),
             "shares_outstanding": clean_value_fn(data.get("SharesOutstanding")),
         }
+        formatted_data["marketSession"] = exchange_session_service_module.get_market_session(
+            asset["market"],
+            exchange=formatted_data.get("exchange") or asset.get("exchange"),
+        )
         return jsonify_fn(formatted_data)
     except Exception as exc:
         logger.error(f"Fundamentals error for {ticker}: {exc}")
@@ -259,6 +276,25 @@ def get_economic_calendar_handler(
         if calendar_cache["data"] is not None:
             return jsonify_fn(calendar_cache["data"])
         return jsonify_fn({"error": str(exc)}), 500
+
+
+def get_market_sessions_handler(
+    *,
+    request_obj,
+    jsonify_fn,
+    logger,
+    exchange_session_service_module,
+):
+    market = str(request_obj.args.get("market", "us")).strip()
+    days = request_obj.args.get("days", default=14, type=int)
+    try:
+        payload = exchange_session_service_module.get_market_sessions_calendar(market, days=days)
+        return jsonify_fn(payload)
+    except exchange_session_service_module.ExchangeSessionError as exc:
+        return jsonify_fn({"error": str(exc)}), 400
+    except Exception as exc:
+        logger.error(f"Market sessions calendar error for {market}: {exc}")
+        return jsonify_fn({"error": "Failed to load market sessions."}), 500
 
 
 def get_financial_statements_handler(

--- a/backend/exchange_session_service.py
+++ b/backend/exchange_session_service.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+import exchange_calendars as exchange_calendars_module
+
+from asset_identity import market_exchange, normalize_market
+
+
+MARKET_SESSION_CONFIG = {
+    "US": {
+        "calendarCode": "XNYS",
+        "timezone": "America/New_York",
+        "defaultExchange": "US",
+        "marketLabel": "United States",
+    },
+    "HK": {
+        "calendarCode": "XHKG",
+        "timezone": "Asia/Hong_Kong",
+        "defaultExchange": "HKEX",
+        "marketLabel": "Hong Kong",
+    },
+    "CN": {
+        "calendarCode": "XSHG",
+        "timezone": "Asia/Shanghai",
+        "defaultExchange": "SSE",
+        "marketLabel": "China A-Shares",
+    },
+}
+
+DEFAULT_SESSION_LOOKAHEAD_DAYS = 14
+MAX_SESSION_LOOKAHEAD_DAYS = 30
+
+
+class ExchangeSessionError(Exception):
+    pass
+
+
+def get_market_session(
+    market: Optional[str],
+    *,
+    exchange: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    config = _get_market_config(market)
+    calendar = _get_calendar(config["calendarCode"])
+    calendar_timezone = config["timezone"]
+    current_minute = _coerce_current_minute(now)
+    local_now = current_minute.tz_convert(calendar_timezone)
+    local_date = local_now.date()
+    exchange_name = exchange or market_exchange(config["market"])
+
+    session_label, session_row = _session_for_local_date(calendar, local_date)
+    if session_label is not None and session_row is not None:
+        return _build_today_session_payload(
+            calendar=calendar,
+            market=config["market"],
+            exchange=exchange_name,
+            calendar_code=config["calendarCode"],
+            session_label=session_label,
+            session_row=session_row,
+            current_minute=current_minute,
+            local_date=local_date,
+        )
+
+    next_open = _safe_calendar_call(calendar.next_open, current_minute)
+    next_close = _safe_calendar_call(calendar.next_close, current_minute)
+    weekend = local_now.weekday() >= 5
+    return {
+        "calendarCode": config["calendarCode"],
+        "market": config["market"],
+        "exchange": exchange_name,
+        "timezone": calendar_timezone,
+        "status": "closed" if weekend else "holiday",
+        "isTradingDay": False,
+        "sessionDate": local_date.isoformat(),
+        "opensAt": None,
+        "closesAt": None,
+        "breakStart": None,
+        "breakEnd": None,
+        "nextOpen": _serialize_timestamp(next_open, timezone=calendar_timezone),
+        "nextClose": _serialize_timestamp(next_close, timezone=calendar_timezone),
+        "reason": "weekend" if weekend else "holiday",
+    }
+
+
+def get_market_sessions_calendar(
+    market: Optional[str],
+    *,
+    days: int = DEFAULT_SESSION_LOOKAHEAD_DAYS,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    config = _get_market_config(market)
+    calendar = _get_calendar(config["calendarCode"])
+    calendar_timezone = config["timezone"]
+    current_minute = _coerce_current_minute(now)
+    today_summary = get_market_session(config["market"], exchange=config["defaultExchange"], now=current_minute)
+
+    session_count = max(1, min(int(days or DEFAULT_SESSION_LOOKAHEAD_DAYS), MAX_SESSION_LOOKAHEAD_DAYS))
+    first_session_label = _resolve_first_session_label(calendar, current_minute)
+    schedule_slice = _slice_schedule(calendar, first_session_label, session_count)
+
+    sessions = [
+        _build_schedule_entry(
+            calendar=calendar,
+            market=config["market"],
+            exchange=config["defaultExchange"],
+            calendar_code=config["calendarCode"],
+            session_label=session_label,
+            session_row=session_row,
+        )
+        for session_label, session_row in schedule_slice.iterrows()
+    ]
+
+    lookahead_end = current_minute.tz_convert(calendar_timezone).date() + timedelta(days=max(session_count * 4, 30))
+    upcoming_holidays = _collect_upcoming_holidays(calendar, current_minute.tz_convert(calendar_timezone).date(), lookahead_end)
+    special_sessions = [
+        {
+            "sessionDate": session["sessionDate"],
+            "type": "early_close",
+            "closesAt": session["closesAt"],
+            "exchange": session["exchange"],
+        }
+        for session in sessions
+        if session.get("isEarlyClose")
+    ]
+
+    return {
+        "market": config["market"],
+        "marketLabel": config["marketLabel"],
+        "exchange": config["defaultExchange"],
+        "calendarCode": config["calendarCode"],
+        "timezone": calendar_timezone,
+        "today": today_summary,
+        "sessions": sessions,
+        "upcomingHolidays": upcoming_holidays,
+        "specialSessions": special_sessions,
+    }
+
+
+def _build_today_session_payload(
+    *,
+    calendar,
+    market: str,
+    exchange: str,
+    calendar_code: str,
+    session_label,
+    session_row,
+    current_minute: pd.Timestamp,
+    local_date: date,
+) -> Dict[str, Any]:
+    open_minute = _to_timestamp(session_row["open"])
+    close_minute = _to_timestamp(session_row["close"])
+    break_start = _to_optional_timestamp(session_row.get("break_start"))
+    break_end = _to_optional_timestamp(session_row.get("break_end"))
+    timezone = str(calendar.tz)
+
+    if break_start is not None and break_end is not None and break_start <= current_minute < break_end:
+        status = "break"
+        reason = "lunch_break"
+        next_open = break_end
+        next_close = close_minute
+    elif open_minute <= current_minute < close_minute:
+        status = "open"
+        reason = "regular_hours"
+        next_open = _safe_calendar_call(calendar.next_open, current_minute)
+        next_close = close_minute
+    else:
+        status = "closed"
+        reason = "outside_hours"
+        next_open = open_minute if current_minute < open_minute else _safe_calendar_call(calendar.next_open, current_minute)
+        next_close = close_minute if current_minute <= close_minute else _safe_calendar_call(calendar.next_close, current_minute)
+
+    return {
+        "calendarCode": calendar_code,
+        "market": market,
+        "exchange": exchange,
+        "timezone": timezone,
+        "status": status,
+        "isTradingDay": True,
+        "sessionDate": session_label.date().isoformat() if hasattr(session_label, "date") else local_date.isoformat(),
+        "opensAt": _serialize_timestamp(open_minute, timezone=timezone),
+        "closesAt": _serialize_timestamp(close_minute, timezone=timezone),
+        "breakStart": _serialize_timestamp(break_start, timezone=timezone),
+        "breakEnd": _serialize_timestamp(break_end, timezone=timezone),
+        "nextOpen": _serialize_timestamp(next_open, timezone=timezone),
+        "nextClose": _serialize_timestamp(next_close, timezone=timezone),
+        "reason": reason,
+    }
+
+
+def _build_schedule_entry(
+    *,
+    calendar,
+    market: str,
+    exchange: str,
+    calendar_code: str,
+    session_label,
+    session_row,
+) -> Dict[str, Any]:
+    timezone = str(calendar.tz)
+    open_minute = _to_timestamp(session_row["open"])
+    close_minute = _to_timestamp(session_row["close"])
+    break_start = _to_optional_timestamp(session_row.get("break_start"))
+    break_end = _to_optional_timestamp(session_row.get("break_end"))
+    return {
+        "calendarCode": calendar_code,
+        "market": market,
+        "exchange": exchange,
+        "timezone": timezone,
+        "sessionDate": session_label.date().isoformat() if hasattr(session_label, "date") else str(session_label)[:10],
+        "opensAt": _serialize_timestamp(open_minute, timezone=timezone),
+        "closesAt": _serialize_timestamp(close_minute, timezone=timezone),
+        "breakStart": _serialize_timestamp(break_start, timezone=timezone),
+        "breakEnd": _serialize_timestamp(break_end, timezone=timezone),
+        "hasBreak": break_start is not None and break_end is not None,
+        "isEarlyClose": _is_early_close(calendar, session_label, close_minute),
+    }
+
+
+def _collect_upcoming_holidays(calendar, start_date: date, end_date: date) -> list[Dict[str, Any]]:
+    closures: list[Dict[str, Any]] = []
+    for day in pd.date_range(start_date, end_date, freq="D"):
+        current_date = day.date()
+        if current_date.weekday() >= 5:
+            continue
+        session_label, _ = _session_for_local_date(calendar, current_date)
+        if session_label is not None:
+            continue
+        closures.append(
+            {
+                "date": current_date.isoformat(),
+                "label": "Market holiday",
+                "reason": "holiday",
+            }
+        )
+        if len(closures) >= 6:
+            break
+    return closures
+
+
+def _resolve_first_session_label(calendar, current_minute: pd.Timestamp):
+    local_date = current_minute.tz_convert(calendar.tz).date()
+    session_label, session_row = _session_for_local_date(calendar, local_date)
+    if session_label is not None and session_row is not None:
+        return session_label
+    next_open = calendar.next_open(current_minute)
+    return calendar.minute_to_session(next_open, direction="next")
+
+
+def _slice_schedule(calendar, first_session_label, session_count: int):
+    schedule = calendar.schedule
+    first_index = schedule.index.get_loc(first_session_label)
+    return schedule.iloc[first_index : first_index + session_count]
+
+
+def _session_for_local_date(calendar, local_date: date):
+    try:
+        session_label = calendar.date_to_session(local_date, direction="none")
+    except Exception:
+        return None, None
+    try:
+        session_row = calendar.schedule.loc[session_label]
+    except KeyError:
+        return None, None
+    return session_label, session_row
+
+
+def _is_early_close(calendar, session_label, close_minute: pd.Timestamp) -> bool:
+    regular_close_time = _effective_time_for_session(calendar.close_times, session_label.date())
+    if regular_close_time is None:
+        return False
+    local_close_time = close_minute.tz_convert(calendar.tz).time()
+    return local_close_time != regular_close_time
+
+
+def _effective_time_for_session(time_rules, session_date: date):
+    if not time_rules:
+        return None
+    session_marker = pd.Timestamp(session_date)
+    selected = None
+    for effective_date, time_value in time_rules:
+        if effective_date is None:
+            selected = time_value
+            continue
+        if pd.Timestamp(effective_date) <= session_marker:
+            selected = time_value
+            continue
+        break
+    return selected
+
+
+def _get_market_config(market: Optional[str]) -> Dict[str, Any]:
+    normalized_market = normalize_market(market, default="US")
+    if normalized_market not in MARKET_SESSION_CONFIG:
+        raise ExchangeSessionError(f"Unsupported market '{market}'.")
+    return {
+        "market": normalized_market,
+        **MARKET_SESSION_CONFIG[normalized_market],
+    }
+
+
+@lru_cache(maxsize=len(MARKET_SESSION_CONFIG))
+def _get_calendar(calendar_code: str):
+    return exchange_calendars_module.get_calendar(calendar_code)
+
+
+def _coerce_current_minute(now: Optional[datetime]) -> pd.Timestamp:
+    if now is None:
+        current = pd.Timestamp.utcnow()
+    else:
+        current = pd.Timestamp(now)
+    if current.tzinfo is None:
+        current = current.tz_localize("UTC")
+    return current.tz_convert("UTC").floor("min")
+
+
+def _to_timestamp(value) -> pd.Timestamp:
+    return pd.Timestamp(value)
+
+
+def _to_optional_timestamp(value) -> Optional[pd.Timestamp]:
+    if value is None or pd.isna(value):
+        return None
+    return pd.Timestamp(value)
+
+
+def _serialize_timestamp(value, *, timezone: Optional[str] = None) -> Optional[str]:
+    if value is None:
+        return None
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize("UTC")
+    if timezone:
+        timestamp = timestamp.tz_convert(timezone)
+    return timestamp.isoformat()
+
+
+def _safe_calendar_call(fn, current_minute: pd.Timestamp):
+    try:
+        return fn(current_minute)
+    except Exception:
+        return None

--- a/backend/marketmind_ai.py
+++ b/backend/marketmind_ai.py
@@ -26,6 +26,7 @@ from openrouter_client import (
     create_chat_completion,
     create_structured_completion,
 )
+import exchange_session_service
 import sec_filings_service
 from user_state_store import (
     Deliverable,
@@ -1278,10 +1279,19 @@ def build_marketmind_ai_context(
         base_context["recentNews"] = international_context.get("recentNews") or []
         base_context["fundamentalsSummary"] = international_context.get("fundamentalsSummary") or {}
         base_context["companyResearchSummary"] = international_context.get("companyResearch") or {}
+        base_context["marketSession"] = exchange_session_service.get_market_session(
+            asset["market"],
+            exchange=international_context.get("exchange") or asset["exchange"],
+        )
     else:
         base_context["predictionSnapshot"] = _prediction_snapshot(normalized_ticker)
         base_context["recentNews"] = _recent_news(normalized_ticker)
         base_context["fundamentalsSummary"] = _fundamentals_summary(normalized_ticker)
+        if asset:
+            base_context["marketSession"] = exchange_session_service.get_market_session(
+                asset["market"],
+                exchange=asset["exchange"],
+            )
         try:
             sec_intelligence = sec_filings_service.get_company_sec_intelligence(normalized_ticker)
         except Exception:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ click==8.1.8
 cryptography==44.0.1
 curl_cffi==0.13.0
 edgartools==5.23.3
+exchange_calendars==4.13.2
 deprecation==2.1.0
 finnhub-python==2.4.25
 Flask==3.1.2

--- a/backend/tests/test_exchange_session_routes.py
+++ b/backend/tests/test_exchange_session_routes.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import unittest
+
+import pandas as pd
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import api as backend_api
+
+
+class _FakeTicker:
+    def __init__(self, symbol):
+        self.symbol = symbol
+        self.quarterly_financials = pd.DataFrame()
+
+    @property
+    def info(self):
+        return {
+            "regularMarketPrice": 187.2,
+            "previousClose": 185.0,
+            "marketCap": 3100000000000,
+            "exchange": "NASDAQ",
+            "currency": "USD",
+            "longName": "Apple Inc.",
+            "forwardPE": 28.4,
+            "pegRatio": 2.1,
+            "priceToBook": 44.2,
+            "beta": 1.18,
+            "dividendYield": 0.0045,
+            "numberOfAnalystOpinions": 37,
+            "trailingPE": 30.6,
+            "fiftyTwoWeekHigh": 210.0,
+            "fiftyTwoWeekLow": 164.0,
+            "targetMeanPrice": 215.0,
+            "recommendationKey": "buy",
+            "longBusinessSummary": "Apple designs consumer hardware and software products.",
+        }
+
+    def history(self, period="7d", interval="1d"):
+        return pd.DataFrame(
+            {
+                "Open": [181.0, 183.0],
+                "High": [185.0, 188.0],
+                "Low": [180.0, 182.0],
+                "Close": [184.0, 187.2],
+                "Volume": [1000, 1200],
+            },
+            index=pd.to_datetime(["2026-04-01", "2026-04-02"]),
+        )
+
+
+class _FakeYFinanceModule:
+    @staticmethod
+    def Ticker(symbol):
+        return _FakeTicker(symbol)
+
+
+class ExchangeSessionRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.original = {
+            "yf": backend_api.yf,
+            "alpha_vantage_key": backend_api.ALPHA_VANTAGE_API_KEY,
+            "fundamentals_from_yfinance": backend_api.api_market_utils_helpers.fundamentals_from_yfinance,
+        }
+        backend_api.yf = _FakeYFinanceModule
+        backend_api.ALPHA_VANTAGE_API_KEY = ""
+        backend_api.api_market_utils_helpers.fundamentals_from_yfinance = lambda sym, **kwargs: {
+            "symbol": sym,
+            "name": "Apple Inc.",
+            "description": "Apple designs consumer hardware and software products.",
+            "exchange": "NASDAQ",
+            "currency": "USD",
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+        }
+        backend_api.app.testing = True
+        self.client = backend_api.app.test_client()
+
+    def tearDown(self):
+        backend_api.yf = self.original["yf"]
+        backend_api.ALPHA_VANTAGE_API_KEY = self.original["alpha_vantage_key"]
+        backend_api.api_market_utils_helpers.fundamentals_from_yfinance = self.original["fundamentals_from_yfinance"]
+
+    def test_stock_route_includes_market_session(self):
+        response = self.client.get("/stock/AAPL")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIn("marketSession", payload)
+        self.assertEqual(payload["marketSession"]["calendarCode"], "XNYS")
+        self.assertEqual(payload["marketSession"]["market"], "US")
+
+    def test_fundamentals_route_includes_market_session(self):
+        response = self.client.get("/fundamentals/AAPL")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIn("marketSession", payload)
+        self.assertEqual(payload["marketSession"]["calendarCode"], "XNYS")
+        self.assertEqual(payload["marketSession"]["market"], "US")
+
+    def test_market_sessions_route_returns_normalized_schedule(self):
+        response = self.client.get("/calendar/market-sessions?market=hk&days=3")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["calendarCode"], "XHKG")
+        self.assertEqual(payload["market"], "HK")
+        self.assertEqual(len(payload["sessions"]), 3)
+        self.assertIn("today", payload)
+        self.assertIn("upcomingHolidays", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_exchange_session_service.py
+++ b/backend/tests/test_exchange_session_service.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import exchange_session_service
+
+
+class ExchangeSessionServiceTests(unittest.TestCase):
+    def test_market_mapping_uses_expected_calendar_codes(self):
+        self.assertEqual(exchange_session_service.get_market_session("us")["calendarCode"], "XNYS")
+        self.assertEqual(exchange_session_service.get_market_session("hk")["calendarCode"], "XHKG")
+        self.assertEqual(exchange_session_service.get_market_session("cn")["calendarCode"], "XSHG")
+
+    def test_hong_kong_lunch_break_is_reported_as_break(self):
+        payload = exchange_session_service.get_market_session(
+            "hk",
+            now=datetime(2026, 4, 2, 4, 20, tzinfo=timezone.utc),
+        )
+        self.assertEqual(payload["status"], "break")
+        self.assertEqual(payload["reason"], "lunch_break")
+        self.assertEqual(payload["calendarCode"], "XHKG")
+        self.assertIsNotNone(payload["breakStart"])
+        self.assertIsNotNone(payload["breakEnd"])
+        self.assertIsNotNone(payload["nextOpen"])
+
+    def test_mainland_china_lunch_break_is_reported_as_break(self):
+        payload = exchange_session_service.get_market_session(
+            "cn",
+            now=datetime(2026, 4, 2, 4, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(payload["status"], "break")
+        self.assertEqual(payload["reason"], "lunch_break")
+        self.assertEqual(payload["calendarCode"], "XSHG")
+
+    def test_us_weekend_returns_closed_with_next_open(self):
+        payload = exchange_session_service.get_market_session(
+            "us",
+            now=datetime(2026, 4, 4, 15, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(payload["status"], "closed")
+        self.assertEqual(payload["reason"], "weekend")
+        self.assertFalse(payload["isTradingDay"])
+        self.assertIsNotNone(payload["nextOpen"])
+        self.assertIsNotNone(payload["nextClose"])
+
+    def test_market_sessions_calendar_returns_upcoming_schedule(self):
+        payload = exchange_session_service.get_market_sessions_calendar(
+            "us",
+            days=3,
+            now=datetime(2026, 4, 2, 15, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(payload["calendarCode"], "XNYS")
+        self.assertEqual(payload["today"]["market"], "US")
+        self.assertEqual(len(payload["sessions"]), 3)
+        self.assertIn("opensAt", payload["sessions"][0])
+        self.assertIn("closesAt", payload["sessions"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_marketmind_ai_api.py
+++ b/backend/tests/test_marketmind_ai_api.py
@@ -250,6 +250,8 @@ class MarketMindAiApiTests(unittest.TestCase):
             self.assertEqual(context_payload["market"], "HK")
             self.assertEqual(context_payload["fundamentalsSummary"]["companyName"], "Tencent Holdings")
             self.assertEqual(context_payload["recentNews"][0]["title"], "Tencent announces annual results")
+            self.assertEqual(context_payload["marketSession"]["calendarCode"], "XHKG")
+            self.assertEqual(context_payload["marketSession"]["market"], "HK")
             self.assertNotIn("secFilingsSummary", context_payload)
 
             preflight_response = self.client.post(
@@ -283,6 +285,8 @@ class MarketMindAiApiTests(unittest.TestCase):
         context_payload = context_response.get_json()
         self.assertTrue(context_payload["watchlistMembership"])
         self.assertEqual(context_payload["fundamentalsSummary"]["companyName"], "Apple Inc.")
+        self.assertEqual(context_payload["marketSession"]["calendarCode"], "XNYS")
+        self.assertEqual(context_payload["marketSession"]["market"], "US")
         self.assertEqual(context_payload["secFilingsSummary"]["type"], "10-K")
         self.assertEqual(context_payload["secFilingsSummary"]["sections"][0]["key"], "riskFactors")
         self.assertEqual(context_payload["filingChangeSummary"]["comparisonForm"], "10-K")

--- a/backend/tests/test_route_registration_smoke.py
+++ b/backend/tests/test_route_registration_smoke.py
@@ -53,6 +53,7 @@ class RouteRegistrationSmokeTests(unittest.TestCase):
             "/fundamentals/filings/<string:ticker>/<string:accession_number>": {"GET"},
             "/search-symbols": {"GET"},
             "/calendar/economic": {"GET"},
+            "/calendar/market-sessions": {"GET"},
             "/macro/overview": {"GET"},
             "/healthz": {"GET"},
             "/api/public/docs": {"GET"},

--- a/frontend/src/components/FundamentalsPage.js
+++ b/frontend/src/components/FundamentalsPage.js
@@ -14,6 +14,12 @@ import {
     Activity,
 } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import {
+    getMarketSessionLabel,
+    getMarketSessionSummary,
+    getMarketSessionToneClasses,
+    getTimezoneLabel,
+} from './ui/marketSessionUtils';
 
 const US_TABS = [
     { key: 'overview', label: 'Overview' },
@@ -261,6 +267,7 @@ const FundamentalsPage = () => {
     const activeAsset = resolvedAsset || (fundamentals ? normalizeAssetInput(fundamentals.assetId || fundamentals.symbol, fundamentals.market || selectedMarket) : null);
     const internationalResearchMode = activeAsset && !isUsAsset(activeAsset);
     const tabs = internationalResearchMode ? INTERNATIONAL_TABS : US_TABS;
+    const marketSession = fundamentals?.marketSession || null;
 
     const handleSearch = async (e) => {
         e.preventDefault();
@@ -519,6 +526,20 @@ const FundamentalsPage = () => {
                                             <span>•</span>
                                             <span>{fundamentals.currency}</span>
                                         </div>
+                                        {marketSession ? (
+                                            <div className="mt-4 rounded-card border border-mm-border bg-mm-surface-subtle px-4 py-3">
+                                                <div className="flex flex-wrap items-center gap-2 text-xs text-mm-text-secondary">
+                                                    <span className={`rounded-pill border px-2.5 py-1 font-semibold uppercase tracking-[0.12em] ${getMarketSessionToneClasses(marketSession)}`}>
+                                                        {getMarketSessionLabel(marketSession)}
+                                                    </span>
+                                                    <span>{marketSession.exchange || fundamentals.exchange}</span>
+                                                    {marketSession.timezone ? <span>• {getTimezoneLabel(marketSession.timezone)}</span> : null}
+                                                </div>
+                                                <p className="mt-2 text-sm text-mm-text-secondary">
+                                                    {getMarketSessionSummary(marketSession)}
+                                                </p>
+                                            </div>
+                                        ) : null}
                                     </div>
                                     <div className="text-left lg:text-right">
                                         <p className="ui-section-label mb-2">Sector</p>

--- a/frontend/src/components/FundamentalsPage.test.js
+++ b/frontend/src/components/FundamentalsPage.test.js
@@ -25,6 +25,13 @@ const fundamentalsPayload = {
     pe_ratio: 30.5,
     eps: 6.2,
     beta: 1.2,
+    marketSession: {
+        status: 'open',
+        exchange: 'NASDAQ',
+        timezone: 'America/New_York',
+        closesAt: '2026-04-02T16:00:00-04:00',
+        reason: 'regular_hours',
+    },
 };
 
 const financialsPayload = {
@@ -139,6 +146,14 @@ const hkFundamentalsPayload = {
     day_50_moving_average: 365,
     day_200_moving_average: 332,
     shares_outstanding: null,
+    marketSession: {
+        status: 'break',
+        exchange: 'HKEX',
+        timezone: 'Asia/Hong_Kong',
+        closesAt: '2026-04-02T16:00:00+08:00',
+        nextOpen: '2026-04-02T13:00:00+08:00',
+        reason: 'lunch_break',
+    },
     researchProfile: [
         { label: 'Company', value: 'Tencent Holdings Limited' },
         { label: 'Industry', value: 'Internet Services' },
@@ -241,6 +256,8 @@ describe('FundamentalsPage', () => {
         expect(screen.getByRole('button', { name: 'Company Research' })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'SEC Filings' })).not.toBeInTheDocument();
         expect(screen.getByText(/Akshare international mode is read-only/i)).toBeInTheDocument();
+        expect(screen.getByText('Lunch Break')).toBeInTheDocument();
+        expect(screen.getByText(/Reopens at/i)).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('button', { name: 'Company Research' }));
 

--- a/frontend/src/components/MarketCalendarPage.js
+++ b/frontend/src/components/MarketCalendarPage.js
@@ -9,12 +9,30 @@ import {
     Activity
 } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import {
+    formatMarketSessionDateTime,
+    getMarketSessionLabel,
+    getMarketSessionSummary,
+    getMarketSessionToneClasses,
+    getTimezoneLabel,
+} from './ui/marketSessionUtils';
+
+const SESSION_MARKETS = [
+    { value: 'us', label: 'US' },
+    { value: 'hk', label: 'HK' },
+    { value: 'cn', label: 'CN' },
+];
 
 const MarketCalendarPage = () => {
     const [events, setEvents] = useState([]);
+    const [sessionPayload, setSessionPayload] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [sessionLoading, setSessionLoading] = useState(false);
+    const [sessionError, setSessionError] = useState('');
     const [filter, setFilter] = useState('all'); // 'all', 'report', 'speaker'
     const [searchQuery, setSearchQuery] = useState('');
+    const [activeView, setActiveView] = useState('economic');
+    const [selectedMarket, setSelectedMarket] = useState('us');
 
     useEffect(() => {
         setLoading(true);
@@ -28,6 +46,22 @@ const MarketCalendarPage = () => {
             .catch(err => console.error("Failed to fetch events:", err))
             .finally(() => setLoading(false));
     }, []);
+
+    useEffect(() => {
+        if (activeView !== 'sessions') {
+            return;
+        }
+        setSessionLoading(true);
+        setSessionError('');
+        apiRequest(API_ENDPOINTS.MARKET_SESSIONS_CALENDAR(selectedMarket))
+            .then((data) => setSessionPayload(data))
+            .catch((err) => {
+                console.error("Failed to fetch market sessions:", err);
+                setSessionPayload(null);
+                setSessionError(err?.message || 'Failed to fetch market sessions.');
+            })
+            .finally(() => setSessionLoading(false));
+    }, [activeView, selectedMarket]);
 
     // Filter and search logic
     const filteredEvents = events.filter(event => {
@@ -64,44 +98,178 @@ const MarketCalendarPage = () => {
                 <div>
                     <h1 className="ui-page-title flex items-center">
                         <CalendarIcon className="w-8 h-8 mr-3 text-mm-accent-primary" />
-                        U.S. Economic Calendar
+                        {activeView === 'economic' ? 'U.S. Economic Calendar' : 'Market Sessions'}
                     </h1>
                     <p className="ui-page-subtitle mt-2 max-w-xl">
-                        Track live macroeconomic reports and Federal Reserve speaker schedules.
+                        {activeView === 'economic'
+                            ? 'Track live macroeconomic reports and Federal Reserve speaker schedules.'
+                            : 'Understand regular trading sessions, lunch breaks, and upcoming holidays across US, Hong Kong, and mainland China.'}
                     </p>
                 </div>
 
-                {/* Search & Filters */}
-                <div className="flex flex-col sm:flex-row gap-3 w-full md:w-auto">
-                    <div className="relative flex-1 sm:flex-none">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                        <input
-                            type="text"
-                            placeholder="Search events..."
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            className="ui-input w-full sm:w-60 py-2 pl-9 text-sm"
-                        />
-                    </div>
+                <div className="flex flex-col gap-3 w-full md:w-auto">
                     <div className="ui-tab-group flex">
-                        {['all', 'report', 'speaker'].map((f) => (
+                        {[
+                            { key: 'economic', label: 'Economic' },
+                            { key: 'sessions', label: 'Market Sessions' },
+                        ].map((view) => (
                             <button
-                                key={f}
-                                onClick={() => setFilter(f)}
-                                className={`px-4 py-1.5 text-xs capitalize ${
-                                    filter === f 
+                                key={view.key}
+                                onClick={() => setActiveView(view.key)}
+                                className={`px-4 py-1.5 text-xs ${
+                                    activeView === view.key
                                         ? 'ui-tab ui-tab-active'
                                         : 'ui-tab'
                                 }`}
                             >
-                                {f === 'all' ? 'All Events' : f + 's'}
+                                {view.label}
                             </button>
                         ))}
                     </div>
+                    {activeView === 'economic' ? (
+                        <div className="flex flex-col sm:flex-row gap-3 w-full md:w-auto">
+                            <div className="relative flex-1 sm:flex-none">
+                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                                <input
+                                    type="text"
+                                    placeholder="Search events..."
+                                    value={searchQuery}
+                                    onChange={(e) => setSearchQuery(e.target.value)}
+                                    className="ui-input w-full sm:w-60 py-2 pl-9 text-sm"
+                                />
+                            </div>
+                            <div className="ui-tab-group flex">
+                                {['all', 'report', 'speaker'].map((f) => (
+                                    <button
+                                        key={f}
+                                        onClick={() => setFilter(f)}
+                                        className={`px-4 py-1.5 text-xs capitalize ${
+                                            filter === f 
+                                                ? 'ui-tab ui-tab-active'
+                                                : 'ui-tab'
+                                        }`}
+                                    >
+                                        {f === 'all' ? 'All Events' : f + 's'}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="flex gap-2">
+                            {SESSION_MARKETS.map((marketOption) => (
+                                <button
+                                    key={marketOption.value}
+                                    type="button"
+                                    onClick={() => setSelectedMarket(marketOption.value)}
+                                    className={selectedMarket === marketOption.value ? 'ui-chip bg-mm-accent-primary text-white border-mm-accent-primary' : 'ui-chip'}
+                                >
+                                    {marketOption.label}
+                                </button>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </div>
 
-            {/* Dense Data Table Layout */}
+            {activeView === 'sessions' ? (
+                <div className="space-y-6">
+                    {sessionLoading ? (
+                        <div className="ui-panel py-20 flex justify-center items-center">
+                            <div className="animate-spin rounded-full h-8 w-8 border-4 border-mm-accent-primary border-t-transparent"></div>
+                        </div>
+                    ) : sessionError ? (
+                        <div className="rounded-card border border-mm-negative/20 bg-mm-negative/10 px-6 py-4 text-mm-negative">
+                            {sessionError}
+                        </div>
+                    ) : sessionPayload ? (
+                        <>
+                            <div className="ui-panel p-6">
+                                <div className="flex flex-wrap items-center gap-3">
+                                    <span className={`rounded-pill border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.12em] ${getMarketSessionToneClasses(sessionPayload.today)}`}>
+                                        {getMarketSessionLabel(sessionPayload.today)}
+                                    </span>
+                                    <span className="text-sm font-semibold text-mm-text-primary">{sessionPayload.exchange}</span>
+                                    <span className="text-sm text-mm-text-secondary">• {getTimezoneLabel(sessionPayload.timezone)}</span>
+                                </div>
+                                <h2 className="mt-4 text-2xl font-semibold text-mm-text-primary">
+                                    {sessionPayload.marketLabel} session today
+                                </h2>
+                                <p className="mt-2 text-sm text-mm-text-secondary">
+                                    {getMarketSessionSummary(sessionPayload.today)}
+                                </p>
+                            </div>
+
+                            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(300px,1fr)]">
+                                <div className="ui-panel overflow-hidden">
+                                    <div className="border-b border-mm-border px-6 py-4">
+                                        <h3 className="text-lg font-semibold text-mm-text-primary">Upcoming Sessions</h3>
+                                    </div>
+                                    <div className="divide-y divide-mm-border">
+                                        {(sessionPayload.sessions || []).map((session) => (
+                                            <div key={`${session.market}-${session.sessionDate}`} className="px-6 py-4">
+                                                <div className="flex flex-wrap items-start justify-between gap-3">
+                                                    <div>
+                                                        <p className="text-sm font-semibold text-mm-text-primary">{session.sessionDate}</p>
+                                                        <p className="mt-1 text-sm text-mm-text-secondary">
+                                                            Opens {formatMarketSessionDateTime(session.opensAt, session.timezone)} • closes {formatMarketSessionDateTime(session.closesAt, session.timezone)}
+                                                        </p>
+                                                        {session.hasBreak ? (
+                                                            <p className="mt-1 text-sm text-mm-text-secondary">
+                                                                Lunch break {formatMarketSessionDateTime(session.breakStart, session.timezone)} to {formatMarketSessionDateTime(session.breakEnd, session.timezone)}
+                                                            </p>
+                                                        ) : null}
+                                                    </div>
+                                                    {session.isEarlyClose ? (
+                                                        <span className="rounded-pill border border-mm-warning/20 bg-mm-warning/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-mm-warning">
+                                                            Early Close
+                                                        </span>
+                                                    ) : null}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div className="space-y-6">
+                                    <div className="ui-panel p-6">
+                                        <h3 className="text-lg font-semibold text-mm-text-primary">Upcoming Holidays</h3>
+                                        {(sessionPayload.upcomingHolidays || []).length > 0 ? (
+                                            <div className="mt-4 space-y-3">
+                                                {sessionPayload.upcomingHolidays.map((holiday) => (
+                                                    <div key={holiday.date} className="rounded-card border border-mm-border bg-mm-surface-subtle px-4 py-3">
+                                                        <p className="text-sm font-semibold text-mm-text-primary">{holiday.date}</p>
+                                                        <p className="mt-1 text-sm text-mm-text-secondary">{holiday.label}</p>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        ) : (
+                                            <p className="mt-4 text-sm text-mm-text-secondary">No weekday market holidays are visible in the current lookahead window.</p>
+                                        )}
+                                    </div>
+
+                                    <div className="ui-panel p-6">
+                                        <h3 className="text-lg font-semibold text-mm-text-primary">Special Sessions</h3>
+                                        {(sessionPayload.specialSessions || []).length > 0 ? (
+                                            <div className="mt-4 space-y-3">
+                                                {sessionPayload.specialSessions.map((session) => (
+                                                    <div key={`${session.sessionDate}-${session.type}`} className="rounded-card border border-mm-border bg-mm-surface-subtle px-4 py-3">
+                                                        <p className="text-sm font-semibold text-mm-text-primary">{session.sessionDate}</p>
+                                                        <p className="mt-1 text-sm text-mm-text-secondary">
+                                                            Early close at {formatMarketSessionDateTime(session.closesAt, sessionPayload.timezone)}
+                                                        </p>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        ) : (
+                                            <p className="mt-4 text-sm text-mm-text-secondary">No early-close sessions are visible in the current lookahead window.</p>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        </>
+                    ) : null}
+                </div>
+            ) : (
             <div className="ui-panel overflow-hidden">
 
                 {/* Desktop Table Header */}
@@ -213,6 +381,7 @@ const MarketCalendarPage = () => {
                     ))
                 )}
             </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/components/MarketCalendarPage.test.js
+++ b/frontend/src/components/MarketCalendarPage.test.js
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import MarketCalendarPage from './MarketCalendarPage';
+import { API_ENDPOINTS, apiRequest } from '../config/api';
+
+jest.mock('../config/api', () => ({
+    API_ENDPOINTS: {
+        ECONOMIC_CALENDAR: '/calendar/economic',
+        MARKET_SESSIONS_CALENDAR: (market = 'us', days = 14) => `/calendar/market-sessions?market=${market}&days=${days}`,
+    },
+    apiRequest: jest.fn(),
+}));
+
+describe('MarketCalendarPage', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('switches into the market sessions view and renders HK session data', async () => {
+        apiRequest.mockImplementation((url) => {
+            if (url === API_ENDPOINTS.ECONOMIC_CALENDAR) {
+                return Promise.resolve([]);
+            }
+            if (url === API_ENDPOINTS.MARKET_SESSIONS_CALENDAR('us', 14)) {
+                return Promise.resolve({
+                    market: 'US',
+                    marketLabel: 'United States',
+                    exchange: 'US',
+                    timezone: 'America/New_York',
+                    today: {
+                        status: 'open',
+                        exchange: 'US',
+                        timezone: 'America/New_York',
+                        closesAt: '2026-04-02T16:00:00-04:00',
+                    },
+                    sessions: [],
+                    upcomingHolidays: [],
+                    specialSessions: [],
+                });
+            }
+            if (url === API_ENDPOINTS.MARKET_SESSIONS_CALENDAR('hk', 14)) {
+                return Promise.resolve({
+                    market: 'HK',
+                    marketLabel: 'Hong Kong',
+                    exchange: 'HKEX',
+                    timezone: 'Asia/Hong_Kong',
+                    today: {
+                        status: 'break',
+                        exchange: 'HKEX',
+                        timezone: 'Asia/Hong_Kong',
+                        closesAt: '2026-04-02T16:00:00+08:00',
+                        nextOpen: '2026-04-02T13:00:00+08:00',
+                        reason: 'lunch_break',
+                    },
+                    sessions: [
+                        {
+                            market: 'HK',
+                            sessionDate: '2026-04-02',
+                            opensAt: '2026-04-02T09:30:00+08:00',
+                            closesAt: '2026-04-02T16:00:00+08:00',
+                            breakStart: '2026-04-02T12:00:00+08:00',
+                            breakEnd: '2026-04-02T13:00:00+08:00',
+                            hasBreak: true,
+                            isEarlyClose: false,
+                            exchange: 'HKEX',
+                            timezone: 'Asia/Hong_Kong',
+                        },
+                    ],
+                    upcomingHolidays: [{ date: '2026-04-06', label: 'Market holiday' }],
+                    specialSessions: [],
+                });
+            }
+            throw new Error(`Unhandled API request: ${url}`);
+        });
+
+        render(<MarketCalendarPage />);
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Market Sessions' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'HK' }));
+
+        expect(await screen.findByText('Hong Kong session today')).toBeInTheDocument();
+        expect(screen.getByText('Lunch Break')).toBeInTheDocument();
+        expect(screen.getByText(/Reopens at/i)).toBeInTheDocument();
+        expect(screen.getByText('Upcoming Sessions')).toBeInTheDocument();
+        expect(screen.getByText('2026-04-06')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/MarketMindAIPage.js
+++ b/frontend/src/components/MarketMindAIPage.js
@@ -13,6 +13,10 @@ import {
     X,
 } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import {
+    getMarketSessionLabel,
+    getMarketSessionSummary,
+} from './ui/marketSessionUtils';
 
 const TEMPLATE_KEY = 'investment_thesis_memo';
 
@@ -694,6 +698,13 @@ const MarketMindAIPage = () => {
                                                 value={`${contextData.recentNews?.length || 0} headlines`}
                                                 caption={contextData.recentNews?.[0]?.title || 'No recent headlines available.'}
                                             />
+                                            {contextData.marketSession ? (
+                                                <ContextCard
+                                                    label="Market session"
+                                                    value={getMarketSessionLabel(contextData.marketSession)}
+                                                    caption={getMarketSessionSummary(contextData.marketSession)}
+                                                />
+                                            ) : null}
                                         </>
                                     ) : (
                                         <div className="rounded-[22px] border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-400">

--- a/frontend/src/components/MarketMindAIPage.test.js
+++ b/frontend/src/components/MarketMindAIPage.test.js
@@ -93,6 +93,13 @@ describe('MarketMindAIPage', () => {
                     ticker: 'NVDA',
                     watchlistMembership: true,
                     activeAlerts: [],
+                    marketSession: {
+                        status: 'open',
+                        exchange: 'NASDAQ',
+                        timezone: 'America/New_York',
+                        closesAt: '2026-04-02T16:00:00-04:00',
+                        reason: 'regular_hours',
+                    },
                     predictionSnapshot: {
                         recentClose: 890,
                         recentPredicted: 905,
@@ -199,6 +206,8 @@ describe('MarketMindAIPage', () => {
         expect((await screen.findAllByText(/Here is a grounded reply/i)).length).toBeGreaterThan(0);
         expect(await screen.findByText(/Valuation/i)).toBeInTheDocument();
         expect((await screen.findAllByText(/Summarize the current setup for NVDA using predictions, news, and fundamentals\./i)).length).toBeGreaterThan(0);
+        expect(await screen.findByText('Market session')).toBeInTheDocument();
+        expect(screen.getByText('Open')).toBeInTheDocument();
 
         await waitFor(() => {
             expect(apiRequest).toHaveBeenCalledWith(

--- a/frontend/src/components/ui/StockDataCard.js
+++ b/frontend/src/components/ui/StockDataCard.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import { TrendingUpIcon, TrendingDownIcon } from '../Icons';
+import {
+    getMarketSessionLabel,
+    getMarketSessionSummary,
+    getMarketSessionToneClasses,
+    getTimezoneLabel,
+} from './marketSessionUtils';
 
 // --- Helper to safely format numbers to 2 decimal places ---
 const formatNum = (num, isPercent = false) => {
@@ -28,6 +34,7 @@ const StockDataCard = ({ data, onAddToWatchlist, canAddToWatchlist = true }) => 
     
     const isPositive = (data.change || 0) >= 0;
     const changeColor = isPositive ? 'text-mm-positive' : 'text-mm-negative';
+    const marketSession = data.marketSession;
 
     const DataRow = ({ label, value }) => (
         <div className="flex justify-between border-b border-mm-border py-3 last:border-b-0">
@@ -49,6 +56,20 @@ const StockDataCard = ({ data, onAddToWatchlist, canAddToWatchlist = true }) => 
                         {data.exchange ? <span>{data.exchange}</span> : null}
                         {data.currency ? <span>• {data.currency}</span> : null}
                     </div>
+                    {marketSession ? (
+                        <div className="mt-3">
+                            <div className="flex flex-wrap items-center gap-2 text-xs text-mm-text-secondary">
+                                <span className={`rounded-pill border px-2.5 py-1 font-semibold uppercase tracking-[0.12em] ${getMarketSessionToneClasses(marketSession)}`}>
+                                    {getMarketSessionLabel(marketSession)}
+                                </span>
+                                <span>{marketSession.exchange || data.exchange}</span>
+                                {marketSession.timezone ? <span>• {getTimezoneLabel(marketSession.timezone)}</span> : null}
+                            </div>
+                            <p className="mt-2 text-sm text-mm-text-secondary">
+                                {getMarketSessionSummary(marketSession)}
+                            </p>
+                        </div>
+                    ) : null}
                     <p className="mt-2 text-3xl font-bold text-mm-text-primary">{pricePrefix}{formatNum(data.price)}</p>
                 </div>
                 <div className="text-right">

--- a/frontend/src/components/ui/StockDataCard.test.js
+++ b/frontend/src/components/ui/StockDataCard.test.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import StockDataCard from './StockDataCard';
+
+describe('StockDataCard', () => {
+    test('renders market session status and timing context when available', () => {
+        render(
+            <StockDataCard
+                data={{
+                    symbol: '00700',
+                    companyName: 'Tencent Holdings',
+                    market: 'HK',
+                    exchange: 'HKEX',
+                    currency: 'HKD',
+                    price: 320.5,
+                    change: 4.8,
+                    changePercent: 1.52,
+                    marketCap: 'N/A',
+                    fundamentals: {},
+                    marketSession: {
+                        status: 'break',
+                        exchange: 'HKEX',
+                        timezone: 'Asia/Hong_Kong',
+                        closesAt: '2026-04-02T16:00:00+08:00',
+                        nextOpen: '2026-04-02T13:00:00+08:00',
+                        reason: 'lunch_break',
+                    },
+                }}
+                onAddToWatchlist={jest.fn()}
+                canAddToWatchlist={false}
+            />
+        );
+
+        expect(screen.getByText('Lunch Break')).toBeInTheDocument();
+        expect(screen.getByText(/Hong Kong/i)).toBeInTheDocument();
+        expect(screen.getByText(/Reopens at/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/ui/marketSessionUtils.js
+++ b/frontend/src/components/ui/marketSessionUtils.js
@@ -1,0 +1,115 @@
+const safeDate = (value) => {
+    if (!value) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+export const getMarketSessionLabel = (session) => {
+    if (!session) return 'Closed';
+    switch (session.status) {
+    case 'open':
+        return 'Open';
+    case 'break':
+        return 'Lunch Break';
+    case 'holiday':
+        return 'Holiday';
+    default:
+        return 'Closed';
+    }
+};
+
+export const getMarketSessionTone = (session) => {
+    if (!session) return 'slate';
+    switch (session.status) {
+    case 'open':
+        return 'positive';
+    case 'break':
+        return 'warning';
+    case 'holiday':
+        return 'negative';
+    default:
+        return 'slate';
+    }
+};
+
+export const getMarketSessionToneClasses = (session) => {
+    switch (getMarketSessionTone(session)) {
+    case 'positive':
+        return 'border-mm-positive/20 bg-mm-positive/10 text-mm-positive';
+    case 'warning':
+        return 'border-mm-warning/20 bg-mm-warning/10 text-mm-warning';
+    case 'negative':
+        return 'border-mm-negative/20 bg-mm-negative/10 text-mm-negative';
+    default:
+        return 'border-mm-border bg-mm-surface-subtle text-mm-text-secondary';
+    }
+};
+
+export const formatMarketSessionTime = (value, timezone, options = {}) => {
+    const parsed = safeDate(value);
+    if (!parsed) return null;
+    try {
+        return new Intl.DateTimeFormat('en-US', {
+            timeZone: timezone || 'UTC',
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'short',
+            ...options,
+        }).format(parsed);
+    } catch (error) {
+        return parsed.toISOString();
+    }
+};
+
+export const formatMarketSessionDateTime = (value, timezone) => {
+    const parsed = safeDate(value);
+    if (!parsed) return null;
+    try {
+        return new Intl.DateTimeFormat('en-US', {
+            timeZone: timezone || 'UTC',
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'short',
+        }).format(parsed);
+    } catch (error) {
+        return parsed.toISOString();
+    }
+};
+
+export const getMarketSessionSummary = (session) => {
+    if (!session) {
+        return 'Session timing unavailable.';
+    }
+    const timezone = session.timezone;
+    if (session.status === 'open') {
+        return session.closesAt
+            ? `Closes at ${formatMarketSessionTime(session.closesAt, timezone)}`
+            : 'Market is in its regular trading session.';
+    }
+    if (session.status === 'break') {
+        const nextOpen = formatMarketSessionTime(session.nextOpen, timezone);
+        const closeTime = formatMarketSessionTime(session.closesAt, timezone);
+        if (nextOpen && closeTime) {
+            return `Reopens at ${nextOpen}; closes at ${closeTime}`;
+        }
+        return 'Market is currently paused for lunch.';
+    }
+    if (session.reason === 'weekend') {
+        return session.nextOpen
+            ? `Weekend. Next open ${formatMarketSessionDateTime(session.nextOpen, timezone)}`
+            : 'Weekend. Next session unavailable.';
+    }
+    if (session.status === 'holiday' || session.reason === 'holiday') {
+        return session.nextOpen
+            ? `Holiday. Next open ${formatMarketSessionDateTime(session.nextOpen, timezone)}`
+            : 'Market holiday.';
+    }
+    if (session.nextOpen) {
+        return `Next open ${formatMarketSessionDateTime(session.nextOpen, timezone)}`;
+    }
+    return 'Outside regular hours.';
+};
+
+export const getTimezoneLabel = (timezone) => String(timezone || '').replace(/_/g, ' ');

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -144,6 +144,8 @@ export const API_ENDPOINTS = {
     MACRO_OVERVIEW: (region = 'us') =>
         buildApiUrl('/macro/overview', region && String(region).toLowerCase() !== 'us' ? { region } : {}),
     ECONOMIC_CALENDAR: `${API_BASE_URL}/calendar/economic`,
+    MARKET_SESSIONS_CALENDAR: (market = 'us', days = 14) =>
+        buildApiUrl('/calendar/market-sessions', { market: String(market || 'us').toLowerCase(), days }),
     
     // Screener
     SCREENER: (category = 'day_gainers') => `${API_BASE_URL}/screener?category=${category}`,

--- a/frontend/src/config/api.test.js
+++ b/frontend/src/config/api.test.js
@@ -87,4 +87,13 @@ describe('API_ENDPOINTS', () => {
             `${API_BASE_URL}/macro/overview?region=asia`
         );
     });
+
+    test('builds market sessions calendar URLs with market and day count', () => {
+        expect(API_ENDPOINTS.MARKET_SESSIONS_CALENDAR()).toBe(
+            `${API_BASE_URL}/calendar/market-sessions?market=us&days=14`
+        );
+        expect(API_ENDPOINTS.MARKET_SESSIONS_CALENDAR('hk', 7)).toBe(
+            `${API_BASE_URL}/calendar/market-sessions?market=hk&days=7`
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- add an internal exchange session service backed by exchange_calendars
- attach normalized marketSession data to stock, fundamentals, and MarketMindAI context
- add an internal /calendar/market-sessions route and market-session UI to Search, Fundamentals, MarketMindAI, and Calendar
- keep public API, watchlist, paper trading, and alerts unchanged

## Verification
- /Users/tazeemmahashin/MarketMind/backend/.venv/bin/python -m unittest -v backend.tests.test_exchange_session_service backend.tests.test_exchange_session_routes backend.tests.test_marketmind_ai_api backend.tests.test_route_registration_smoke
- PYTHON_BIN=/Users/tazeemmahashin/MarketMind/backend/.venv/bin/python bash backend/run_deterministic_backend_checks.sh
- bash frontend/run_frontend_checks.sh

## Notes
- stacked on top of codex/akshare-international-research
- frontend/node_modules is a local symlink for verification only and is intentionally not included