### PR TITLE
feat: upgrade prediction stack with StatsForecast and SHAP

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,5 +1,5 @@
 # To run this file, you need to install all dependencies:
-# pip install Flask Flask-CORS yfinance pandas scikit-learn numpy requests python-dotenv statsmodels finnhub-python vaderSentiment xgboost schedule
+# pip install Flask Flask-CORS yfinance pandas scikit-learn numpy requests python-dotenv statsmodels finnhub-python vaderSentiment xgboost schedule statsforecast mlforecast shap
 
 import os
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -94,6 +94,7 @@ from prediction_market_analysis import (
 import akshare_service
 import exchange_session_service
 import sec_filings_service
+import prediction_service
 from asset_identity import parse_asset_reference
 from logger_config import setup_logger, log_api_error
 from deliverables import (
@@ -1436,6 +1437,7 @@ def predict_stock(model, ticker):
         model,
         ticker,
         create_dataset_fn=create_dataset,
+        future_prediction_dates_fn=prediction_service.get_future_prediction_dates,
         linear_regression_predict_fn=linear_regression_predict,
         random_forest_predict_fn=random_forest_predict,
         xgboost_predict_fn=xgboost_predict,
@@ -1490,6 +1492,7 @@ def predict_ensemble(ticker):
         request_obj=request,
         selective_modes=SELECTIVE_MODES,
         selector_source_requestable=SELECTOR_SOURCE_REQUESTABLE,
+        future_prediction_dates_fn=prediction_service.get_future_prediction_dates,
         yf_module=yf,
         live_ensemble_signal_components_fn=_live_ensemble_signal_components,
         infer_selective_decision_fn=infer_selective_decision,

--- a/backend/api_handlers_market_data.py
+++ b/backend/api_handlers_market_data.py
@@ -365,6 +365,7 @@ def predict_stock_handler(
     ticker,
     *,
     create_dataset_fn,
+    future_prediction_dates_fn,
     linear_regression_predict_fn,
     random_forest_predict_fn,
     xgboost_predict_fn,
@@ -384,8 +385,8 @@ def predict_stock_handler(
         info = stock.info
 
         if model == "LinReg":
-            period = "15d"
-            min_rows = 7
+            period = "6mo"
+            min_rows = 40
         elif model in ("RandomForest", "XGBoost"):
             period = "6mo"
             min_rows = 40
@@ -425,7 +426,9 @@ def predict_stock_handler(
 
         recent_close = float(df["Close"].iloc[-1])
         recent_date = df.index[-1]
-        future_dates = [recent_date + pd_module.Timedelta(days=i + 1) for i in range(len(preds))]
+        future_dates = future_prediction_dates_fn(df, len(preds))
+        if not future_dates:
+            future_dates = [recent_date + pd_module.Timedelta(days=i + 1) for i in range(len(preds))]
 
         response = {
             "symbol": info.get("symbol", sanitized_ticker.upper()),
@@ -450,6 +453,7 @@ def predict_ensemble_handler(
     request_obj,
     selective_modes,
     selector_source_requestable,
+    future_prediction_dates_fn,
     yf_module,
     live_ensemble_signal_components_fn,
     infer_selective_decision_fn,
@@ -481,7 +485,9 @@ def predict_ensemble_handler(
         disagreement = signal_parts["disagreement"]
 
         recent_date = df.index[-1]
-        future_dates = [recent_date + pd_module.Timedelta(days=i + 1) for i in range(len(ensemble_preds))]
+        future_dates = future_prediction_dates_fn(df, len(ensemble_preds))
+        if not future_dates:
+            future_dates = [recent_date + pd_module.Timedelta(days=i + 1) for i in range(len(ensemble_preds))]
 
         selector = infer_selective_decision_fn(
             ticker=sanitized_ticker,
@@ -568,6 +574,10 @@ def evaluate_models_handler(
         default_retrain = 10 if fast_mode else 5
         retrain_frequency = int(request_obj.args.get("retrain_frequency", default_retrain))
         max_train_rows = request_obj.args.get("max_train_rows", default=450 if fast_mode else None, type=int)
+        include_explanations_raw = request_obj.args.get("include_explanations")
+        include_explanations = None
+        if include_explanations_raw is not None:
+            include_explanations = str(include_explanations_raw).strip().lower() in {"1", "true", "yes", "on"}
 
         result = rolling_window_backtest_fn(
             sanitized_ticker,
@@ -577,6 +587,7 @@ def evaluate_models_handler(
             include_selector_variants=include_selector_variants,
             fast_mode=fast_mode,
             max_train_rows=max_train_rows,
+            include_explanations=include_explanations,
         )
         if result is None:
             return jsonify_fn({"error": "Insufficient data for evaluation"}), 404

--- a/backend/api_prediction_runtime.py
+++ b/backend/api_prediction_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import prediction_service
+
 
 def to_bool(value):
     if isinstance(value, bool):
@@ -25,7 +27,6 @@ def live_ensemble_signal_components(
         return None
 
     ensemble_preds, individual_preds = ensemble_predict_fn(df, days_ahead=7)
-    print(f"ensemble_preds length: {len(ensemble_preds)}")
     if ensemble_preds is None or len(ensemble_preds) == 0:
         return None
 
@@ -63,8 +64,10 @@ def chart_prediction_points(
     if ensemble_preds is None or len(ensemble_preds) == 0:
         return []
 
-    recent_date = signal_parts["df"].index[-1]
-    future_dates = [recent_date + pd_module.Timedelta(days=i + 1) for i in range(len(ensemble_preds))]
+    future_dates = prediction_service.get_future_prediction_dates(signal_parts["df"], len(ensemble_preds))
+    if not future_dates:
+        recent_date = signal_parts["df"].index[-1]
+        future_dates = [recent_date + pd_module.Timedelta(days=i + 1) for i in range(len(ensemble_preds))]
     return [
         {
             "date": date.strftime("%Y-%m-%d 00:00:00"),

--- a/backend/deliverables.py
+++ b/backend/deliverables.py
@@ -9,8 +9,8 @@ import yfinance as yf
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
-from models import ensemble_predict, create_dataset
 from openrouter_client import DEFAULT_OPENROUTER_MODEL, create_structured_completion
+from prediction_service import get_prediction_snapshot
 from user_state_store import (
     Deliverable,
     DeliverableAssumption,
@@ -380,30 +380,7 @@ def list_deliverable_memos(session: Session, clerk_user_id: str, deliverable_id:
 
 def _prediction_snapshot(ticker: str) -> Optional[Dict[str, Any]]:
     try:
-        df = create_dataset(ticker, period="1y")
-        if df.empty or len(df) < 30:
-            return None
-        ensemble_preds, model_breakdown = ensemble_predict(df, days_ahead=6)
-        if ensemble_preds is None or len(ensemble_preds) == 0:
-            return None
-        recent_close = float(df["Close"].iloc[-1])
-        model_first_predictions = [float(preds[0]) for preds in model_breakdown.values() if preds is not None and len(preds)]
-        confidence = 85.0
-        if len(model_first_predictions) > 1:
-            mean_prediction = sum(model_first_predictions) / len(model_first_predictions)
-            dispersion = sum(abs(pred - mean_prediction) for pred in model_first_predictions) / len(model_first_predictions)
-            if recent_close:
-                confidence = max(55.0, min(95.0, 95.0 - ((dispersion / recent_close) * 100)))
-        return {
-            "recentClose": round(recent_close, 2),
-            "recentPredicted": round(float(ensemble_preds[0]), 2),
-            "confidence": round(confidence, 1),
-            "modelsUsed": list(model_breakdown.keys()),
-            "predictions": [
-                {"day": index + 1, "predictedClose": round(float(pred), 2)}
-                for index, pred in enumerate(ensemble_preds[:3])
-            ],
-        }
+        return get_prediction_snapshot(ticker)
     except Exception:
         return None
 

--- a/backend/exchange_session_service.py
+++ b/backend/exchange_session_service.py
@@ -142,6 +142,28 @@ def get_market_sessions_calendar(
     }
 
 
+def get_next_session_dates(
+    market: Optional[str],
+    *,
+    after_date,
+    count: int,
+) -> list[pd.Timestamp]:
+    config = _get_market_config(market)
+    calendar = _get_calendar(config["calendarCode"])
+    session_count = max(1, int(count or 1))
+    current_date = pd.Timestamp(after_date).date()
+
+    try:
+        current_session = calendar.date_to_session(current_date, direction="previous")
+    except Exception as exc:
+        raise ExchangeSessionError(f"Unable to resolve session for {current_date.isoformat()}") from exc
+
+    schedule = calendar.schedule
+    session_index = schedule.index.get_loc(current_session)
+    next_schedule = schedule.iloc[session_index + 1 : session_index + 1 + session_count]
+    return [pd.Timestamp(label).tz_localize(None) for label in next_schedule.index]
+
+
 def _build_today_session_payload(
     *,
     calendar,

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,6 +11,7 @@ from statsmodels.tsa.ar_model import AutoReg
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
+import prediction_service
 
 # Try to import XGBoost, fallback if not available
 try:
@@ -22,16 +23,7 @@ except ImportError:
 
 # Creating a dataset based on ticker and period
 def create_dataset(ticker, period):
-    try:
-        data = yf.download(ticker, period=period, auto_adjust=False)
-    except yf.shared.YFPricesMissingError as e:
-        print(f"[Warning] Could not download data for {ticker}: {e}")
-        return pd.DataFrame()
-    if isinstance(data.columns, pd.MultiIndex):
-        data.columns = [col[0] for col in data.columns]
-    df = data[['Close']].copy()
-    df.index = pd.to_datetime(df.index)
-    return df
+    return prediction_service.create_dataset(ticker, period=period)
 
 
 def create_features(df, lookback=14):
@@ -95,181 +87,23 @@ def prepare_model_data(df, lookback=14):
     return X_train_feat, y_train_vals, X_test_feat, y_test_vals
 
 def linear_regression_predict(df, days_ahead=7):
-    """
-    Linear Regression (AutoReg) prediction - existing method
-    """
-    try:
-        df = df.copy()
-        df["Predicted_LR"] = np.nan
-
-        # Get the last available date
-        last_date = df.index[-1]
-
-        for day in range(days_ahead):
-            values = df["Predicted_LR"].fillna(df["Close"]).dropna().values
-
-            # Use AutoReg model
-            model = AutoReg(values, lags=min(5, len(values)-1))
-            model_fit = model.fit()
-
-            next_pred = model_fit.predict(start=len(values), end=len(values))[0]
-            next_date = last_date + pd.Timedelta(days=day+1)
-
-            df.loc[next_date] = [np.nan, next_pred]
-            last_date = next_date
-
-        predictions = df[df["Predicted_LR"].notna()].tail(days_ahead)
-        return predictions["Predicted_LR"].values
-    except Exception as e:
-        print(f"Linear Regression error: {e}")
-        return None
+    return prediction_service.linear_regression_predict(df, days_ahead=days_ahead)
 
 
 def random_forest_predict(df, days_ahead=7, lookback=14):
-    """
-    Random Forest prediction
-    """
-    try:
-        # Prepare data
-        X, y, df_features = prepare_ml_data(df, lookback)
-
-        if len(X) < 30:  # Need minimum data
-            return None
-
-        # Train Random Forest
-        rf_model = RandomForestRegressor(
-            n_estimators=100,
-            max_depth=10,
-            random_state=42,
-            n_jobs=-1
-        )
-        rf_model.fit(X, y)
-
-        # Predict next days
-        predictions = []
-        last_known = df['Close'].iloc[-lookback:].values
-        current_features = df_features.iloc[-1][1:].values  # Exclude Close
-
-        for _ in range(days_ahead):
-            # Reshape for prediction
-            current_X = current_features.reshape(1, -1)
-            next_pred = rf_model.predict(current_X)[0]
-            predictions.append(next_pred)
-
-            # Update features for next prediction (simple rolling)
-            last_known = np.append(last_known[1:], next_pred)
-            # Update lagged features (simplified)
-            current_features[0] = next_pred  # lag_1
-            if len(current_features) > 1:
-                current_features[1] = current_features[0]  # lag_2
-
-        return np.array(predictions)
-    except Exception as e:
-        print(f"Random Forest error: {e}")
-        return None
+    return prediction_service.random_forest_predict(df, days_ahead=days_ahead, lookback=lookback)
 
 
 def xgboost_predict(df, days_ahead=7, lookback=14):
-    """
-    XGBoost prediction
-    """
-    if not XGBOOST_AVAILABLE:
-        return None
-
-    try:
-        # Prepare data
-        X, y, df_features = prepare_ml_data(df, lookback)
-
-        if len(X) < 30:  # Need minimum data
-            return None
-
-        # Train XGBoost
-        xgb_model = xgb.XGBRegressor(
-            n_estimators=100,
-            max_depth=5,
-            learning_rate=0.1,
-            random_state=42,
-            n_jobs=-1
-        )
-        xgb_model.fit(X, y)
-
-        # Predict next days
-        predictions = []
-        last_known = df['Close'].iloc[-lookback:].values
-        current_features = df_features.iloc[-1][1:].values  # Exclude Close
-
-        for _ in range(days_ahead):
-            # Reshape for prediction
-            current_X = current_features.reshape(1, -1)
-            next_pred = xgb_model.predict(current_X)[0]
-            predictions.append(next_pred)
-
-            # Update features for next prediction
-            last_known = np.append(last_known[1:], next_pred)
-            current_features[0] = next_pred  # lag_1
-            if len(current_features) > 1:
-                current_features[1] = current_features[0]  # lag_2
-
-        return np.array(predictions)
-    except Exception as e:
-        print(f"XGBoost error: {e}")
-        return None
+    return prediction_service.xgboost_predict(df, days_ahead=days_ahead, lookback=lookback)
 
 
 def ensemble_predict(df, days_ahead=7):
-    """
-    Ensemble prediction - average of all available models
-    """
-    predictions = {}
-
-    # Get predictions from each model
-    lr_pred = linear_regression_predict(df, days_ahead)
-    rf_pred = random_forest_predict(df, days_ahead)
-    xgb_pred = xgboost_predict(df, days_ahead)
-
-    # LSTM Train and Predict
-    lstm_trained, scaler_X, scaler_y, device = lstm_train(df, lookback=14, seq_len=30, days_ahead=days_ahead, hidden_size=64, layer_size=2, epochs=100, batch_size=32, lr=0.001)
-    lstm_pred = lstm_predict(df, lstm_trained, scaler_X, scaler_y, device, lookback=14, seq_len=30)
-
-    # Transformer Train and Predict
-    transformer_trained, scaler_X, scaler_y, device = transformer_train(df, lookback=14, seq_len=30, days_ahead=days_ahead, d_model=64, nhead=4, num_layers=2, epochs=100, batch_size=32, lr=0.001)
-    transformer_pred = transformer_predict(df, transformer_trained, scaler_X, scaler_y, device, lookback=14, seq_len=30)
-
-    # Store individual predictions
-    if lr_pred is not None:
-        predictions['linear_regression'] = lr_pred
-    if rf_pred is not None:
-        predictions['random_forest'] = rf_pred
-    if xgb_pred is not None:
-        predictions['xgboost'] = xgb_pred
-    if lstm_pred is not None:
-        predictions['lstm'] = lstm_pred
-    if transformer_pred is not None:
-        predictions['transformer'] = transformer_pred
-
-    # Calculate ensemble (weighted average)
-    if len(predictions) == 0:
-        return None, {}
-
-    # Simple average for now (can be weighted later based on historical performance)
-    ensemble = np.mean(list(predictions.values()), axis=0)
-
-    return ensemble, predictions
+    return prediction_service.ensemble_predict(df, days_ahead=days_ahead)
 
 
 def calculate_metrics(actual, predicted):
-    """
-    Calculate accuracy metrics
-    """
-    mae = mean_absolute_error(actual, predicted)
-    rmse = np.sqrt(mean_squared_error(actual, predicted))
-    mape = np.mean(np.abs((actual - predicted) / actual)) * 100
-
-    return {
-        'mae': round(float(mae), 2),
-        'rmse': round(float(rmse), 2),
-        'mape': round(float(mape), 2)
-    }
+    return prediction_service.calculate_metrics(actual, predicted)
 
 # LSTM Class
 class LSTM(nn.Module):

--- a/backend/prediction_service.py
+++ b/backend/prediction_service.py
@@ -1,0 +1,830 @@
+from __future__ import annotations
+
+import copy
+import math
+import time
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import shap
+from mlforecast import MLForecast
+from mlforecast.lag_transforms import RollingMean, RollingStd
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import (
+    mean_absolute_error,
+    mean_absolute_percentage_error,
+    mean_squared_error,
+    r2_score,
+)
+from statsforecast import StatsForecast
+from statsforecast.models import AutoARIMA, Naive, SeasonalNaive
+
+import exchange_session_service
+from data_fetcher import fetch_from_yfinance, get_stock_data_with_fallback, prepare_data_for_ml
+
+try:
+    import xgboost as xgb
+
+    XGBOOST_AVAILABLE = True
+except Exception:
+    xgb = None
+    XGBOOST_AVAILABLE = False
+
+
+FEATURE_SPEC_VERSION = "prediction-stack-v2"
+PREDICTION_HORIZON = 7
+PREDICTION_PREVIEW_HORIZON = 3
+SEASON_LENGTH = 5
+TRADING_DAYS_PER_YEAR = 252
+MIN_HISTORY_ROWS = 40
+MIN_PRODUCTION_HISTORY_ROWS = 120
+CACHE_TTL_SECONDS = 300
+
+PERIOD_SESSION_COUNTS = {
+    "15d": 15,
+    "1mo": 21,
+    "6mo": 126,
+    "1y": 252,
+    "2y": 504,
+}
+
+PRODUCTION_ENSEMBLE_MODELS = (
+    "auto_arima",
+    "linear_regression",
+    "random_forest",
+    "xgboost",
+)
+BENCHMARK_MODELS = ("naive", "seasonal_naive_5", "auto_arima")
+ML_MODELS = ("linear_regression", "random_forest", "xgboost")
+
+_CACHE: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
+
+
+def _cache_get(key: Tuple[Any, ...]) -> Any:
+    entry = _CACHE.get(key)
+    if not entry:
+        return None
+    if time.time() - entry["ts"] > CACHE_TTL_SECONDS:
+        _CACHE.pop(key, None)
+        return None
+    return copy.deepcopy(entry["value"])
+
+
+def _cache_set(key: Tuple[Any, ...], value: Any) -> Any:
+    _CACHE[key] = {"ts": time.time(), "value": copy.deepcopy(value)}
+    return value
+
+
+def _clean_float(value: Any, digits: Optional[int] = None) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except Exception:
+        return None
+    if not math.isfinite(numeric):
+        return None
+    if digits is None:
+        return numeric
+    return round(numeric, digits)
+
+
+def _normalize_ticker(ticker: str) -> str:
+    return str(ticker or "").split(":", 1)[0].strip().upper()
+
+
+def _standardize_ohlcv(df: Optional[pd.DataFrame]) -> pd.DataFrame:
+    if df is None or getattr(df, "empty", True):
+        return pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+    standardized = df.copy()
+    if isinstance(standardized.columns, pd.MultiIndex):
+        standardized.columns = [col[0] for col in standardized.columns]
+    if "Close" not in standardized.columns:
+        if len(standardized.columns) == 1:
+            standardized.columns = ["Close"]
+        else:
+            return pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
+    for column in ("Open", "High", "Low"):
+        if column not in standardized.columns:
+            standardized[column] = standardized["Close"]
+    if "Volume" not in standardized.columns:
+        standardized["Volume"] = 1.0
+    standardized = standardized[["Open", "High", "Low", "Close", "Volume"]].copy()
+    standardized.index = pd.to_datetime(standardized.index)
+    standardized = standardized.sort_index()
+    for column in standardized.columns:
+        standardized[column] = pd.to_numeric(standardized[column], errors="coerce")
+    standardized["Close"] = standardized["Close"].ffill().bfill()
+    standardized["Open"] = standardized["Open"].ffill().bfill().fillna(standardized["Close"])
+    standardized["High"] = standardized["High"].ffill().bfill().fillna(standardized["Close"])
+    standardized["Low"] = standardized["Low"].ffill().bfill().fillna(standardized["Close"])
+    standardized["Volume"] = standardized["Volume"].ffill().bfill().fillna(1.0)
+    standardized = standardized.dropna(subset=["Close"])
+    return standardized
+
+
+def _load_canonical_ohlcv(ticker: str) -> pd.DataFrame:
+    normalized_ticker = _normalize_ticker(ticker)
+    cache_key = ("ohlcv", normalized_ticker)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    df = prepare_data_for_ml(normalized_ticker, min_days=280)
+    if df is None or df.empty:
+        df = get_stock_data_with_fallback(normalized_ticker, min_days=120)
+    if df is None or df.empty:
+        df = fetch_from_yfinance(normalized_ticker, period="2y")
+    standardized = _standardize_ohlcv(df)
+    return _cache_set(cache_key, standardized)
+
+
+def create_dataset(ticker: str, period: str = "1y") -> pd.DataFrame:
+    ohlcv = _load_canonical_ohlcv(ticker)
+    if ohlcv.empty:
+        return pd.DataFrame(columns=["Close"])
+    session_count = PERIOD_SESSION_COUNTS.get(str(period or "1y").lower(), len(ohlcv))
+    close_df = ohlcv.tail(session_count)[["Close"]].copy()
+    close_df.attrs["canonical_ohlcv"] = ohlcv.copy()
+    close_df.attrs["ticker"] = _normalize_ticker(ticker)
+    close_df.attrs["market"] = "US"
+    return close_df
+
+
+def _coerce_ohlcv_from_input(df: pd.DataFrame) -> pd.DataFrame:
+    if isinstance(df, pd.DataFrame) and isinstance(df.attrs.get("canonical_ohlcv"), pd.DataFrame):
+        return _standardize_ohlcv(df.attrs["canonical_ohlcv"])
+    standardized = _standardize_ohlcv(df)
+    return standardized
+
+
+def _build_long_frame(ohlcv: pd.DataFrame, ticker: str) -> pd.DataFrame:
+    dates = pd.to_datetime(ohlcv.index).tz_localize(None)
+    volume = pd.to_numeric(ohlcv["Volume"], errors="coerce").replace(0, np.nan)
+    frame = pd.DataFrame(
+        {
+            "unique_id": _normalize_ticker(ticker),
+            "ds": np.arange(1, len(ohlcv) + 1, dtype=int),
+            "y": pd.to_numeric(ohlcv["Close"], errors="coerce").astype(float),
+            "volume_ratio_5": (
+                volume / volume.rolling(window=5, min_periods=1).mean()
+            ).replace([np.inf, -np.inf], 1.0),
+            "volume_ratio_20": (
+                volume / volume.rolling(window=20, min_periods=1).mean()
+            ).replace([np.inf, -np.inf], 1.0),
+            "session_weekday": dates.weekday.astype(int),
+            "session_month": dates.month.astype(int),
+            "session_quarter": dates.quarter.astype(int),
+        },
+        index=dates,
+    )
+    frame["volume_ratio_5"] = frame["volume_ratio_5"].fillna(1.0)
+    frame["volume_ratio_20"] = frame["volume_ratio_20"].fillna(1.0)
+    return frame
+
+
+def _future_session_dates(last_date: pd.Timestamp, horizon: int) -> List[pd.Timestamp]:
+    return exchange_session_service.get_next_session_dates(
+        "US",
+        after_date=last_date,
+        count=horizon,
+    )
+
+
+def _build_future_exogenous(long_df: pd.DataFrame, future_dates: List[pd.Timestamp]) -> pd.DataFrame:
+    last_row = long_df.iloc[-1]
+    ds_start = int(long_df["ds"].iloc[-1]) + 1
+    rows = []
+    for offset, session_date in enumerate(future_dates):
+        rows.append(
+            {
+                "unique_id": str(long_df["unique_id"].iloc[-1]),
+                "ds": ds_start + offset,
+                "volume_ratio_5": float(last_row["volume_ratio_5"]),
+                "volume_ratio_20": float(last_row["volume_ratio_20"]),
+                "session_weekday": int(session_date.weekday()),
+                "session_month": int(session_date.month),
+                "session_quarter": int(((session_date.month - 1) // 3) + 1),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _build_mlforecast(models: Dict[str, Any]) -> MLForecast:
+    return MLForecast(
+        models=models,
+        freq=1,
+        lags=[1, 2, 3, 5, 10, 20],
+        lag_transforms={
+            1: [RollingMean(3), RollingMean(5), RollingMean(10), RollingStd(3), RollingStd(5), RollingStd(10)],
+            5: [RollingMean(3)],
+        },
+        num_threads=1,
+    )
+
+
+def _build_ml_models() -> Dict[str, Any]:
+    models: Dict[str, Any] = {
+        "linear_regression": LinearRegression(),
+        "random_forest": RandomForestRegressor(
+            n_estimators=200,
+            max_depth=12,
+            min_samples_split=4,
+            min_samples_leaf=2,
+            random_state=42,
+            n_jobs=-1,
+        ),
+    }
+    if XGBOOST_AVAILABLE:
+        models["xgboost"] = xgb.XGBRegressor(
+            n_estimators=200,
+            max_depth=6,
+            learning_rate=0.05,
+            subsample=0.85,
+            colsample_bytree=0.85,
+            random_state=42,
+            n_jobs=1,
+        )
+    return models
+
+
+def _build_statsforecast() -> StatsForecast:
+    return StatsForecast(
+        models=[
+            Naive(alias="naive"),
+            SeasonalNaive(season_length=SEASON_LENGTH, alias="seasonal_naive_5"),
+            AutoARIMA(season_length=SEASON_LENGTH, alias="auto_arima"),
+        ],
+        freq=1,
+        n_jobs=1,
+    )
+
+
+def _forecast_ml_models(
+    ohlcv: pd.DataFrame,
+    *,
+    model_names: Optional[Iterable[str]] = None,
+    horizon: int = PREDICTION_HORIZON,
+    ticker: str = "AAPL",
+) -> Dict[str, Any]:
+    requested = tuple(name for name in (model_names or ML_MODELS) if name in _build_ml_models())
+    cache_key = ("ml_forecast", _normalize_ticker(ticker), tuple(sorted(requested)), len(ohlcv), horizon)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    long_df = _build_long_frame(ohlcv, ticker)
+    future_dates = _future_session_dates(ohlcv.index[-1], horizon)
+    future_x = _build_future_exogenous(long_df, future_dates)
+    models = {name: estimator for name, estimator in _build_ml_models().items() if name in requested}
+    fcst = _build_mlforecast(models)
+    fcst.fit(long_df.reset_index(drop=True), static_features=[])
+    predictions = fcst.predict(h=horizon, X_df=future_x)
+    processed_X, processed_y = fcst.preprocess(long_df.reset_index(drop=True), static_features=[], return_X_y=True)
+    result = {
+        "predictions": {
+            model_name: predictions[model_name].to_numpy(dtype=float)
+            for model_name in models
+            if model_name in predictions.columns
+        },
+        "future_dates": future_dates,
+        "feature_frame": processed_X.reset_index(drop=True),
+        "target": np.asarray(processed_y, dtype=float),
+        "models": fcst.models_,
+    }
+    return _cache_set(cache_key, result)
+
+
+def _forecast_statistical_models(
+    ohlcv: pd.DataFrame,
+    *,
+    horizon: int = PREDICTION_HORIZON,
+    ticker: str = "AAPL",
+) -> Dict[str, Any]:
+    cache_key = ("stats_forecast", _normalize_ticker(ticker), len(ohlcv), horizon)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    long_df = _build_long_frame(ohlcv, ticker)[["unique_id", "ds", "y"]].reset_index(drop=True)
+    sf = _build_statsforecast()
+    forecast = sf.forecast(h=horizon, df=long_df)
+    result = {
+        "predictions": {
+            model_name: forecast[model_name].to_numpy(dtype=float)
+            for model_name in BENCHMARK_MODELS
+            if model_name in forecast.columns
+        },
+    }
+    return _cache_set(cache_key, result)
+
+
+def _compute_weighted_ensemble(model_predictions: Dict[str, np.ndarray], weights: Dict[str, float]) -> np.ndarray:
+    available = [name for name in PRODUCTION_ENSEMBLE_MODELS if name in model_predictions]
+    if not available:
+        return np.array([], dtype=float)
+    normalized_weights = {name: max(float(weights.get(name, 0.0)), 0.0) for name in available}
+    total = sum(normalized_weights.values())
+    if total <= 0:
+        normalized_weights = {name: 1.0 / len(available) for name in available}
+    else:
+        normalized_weights = {name: value / total for name, value in normalized_weights.items()}
+    stacked = np.stack([model_predictions[name] * normalized_weights[name] for name in available], axis=0)
+    return stacked.sum(axis=0)
+
+
+def _default_live_weight_windows(series_length: int) -> int:
+    return max(3, min(8, max(1, series_length // 30)))
+
+
+def _ensemble_weights_from_recent_cv(ohlcv: pd.DataFrame, ticker: str) -> Dict[str, float]:
+    cache_key = ("ensemble_weights", _normalize_ticker(ticker), len(ohlcv))
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        long_df = _build_long_frame(ohlcv, ticker)
+        n_windows = _default_live_weight_windows(len(long_df))
+        input_size = min(max(len(long_df) - n_windows, 60), 180)
+
+        ml_models = _build_ml_models()
+        ml_fcst = _build_mlforecast(ml_models)
+        ml_cv = ml_fcst.cross_validation(
+            df=long_df.reset_index(drop=True),
+            n_windows=n_windows,
+            h=1,
+            step_size=1,
+            refit=1,
+            static_features=[],
+            input_size=input_size,
+        )
+
+        sf = _build_statsforecast()
+        sf_cv = sf.cross_validation(
+            h=1,
+            df=long_df[["unique_id", "ds", "y"]].reset_index(drop=True),
+            n_windows=n_windows,
+            step_size=1,
+            refit=1,
+            input_size=input_size,
+        )
+
+        errors: Dict[str, float] = {}
+        for model_name in ("linear_regression", "random_forest", "xgboost"):
+            if model_name in ml_cv.columns:
+                errors[model_name] = float(mean_absolute_error(ml_cv["y"], ml_cv[model_name]))
+        if "auto_arima" in sf_cv.columns:
+            errors["auto_arima"] = float(mean_absolute_error(sf_cv["y"], sf_cv["auto_arima"]))
+
+        valid = {name: err for name, err in errors.items() if math.isfinite(err) and err > 0}
+        if not valid:
+            raise ValueError("No valid validation errors were produced.")
+
+        inverse = {name: 1.0 / err for name, err in valid.items()}
+        total = sum(inverse.values())
+        weights = {name: value / total for name, value in inverse.items()}
+    except Exception:
+        available = [name for name in PRODUCTION_ENSEMBLE_MODELS if name != "xgboost" or XGBOOST_AVAILABLE]
+        weights = {name: 1.0 / len(available) for name in available}
+
+    return _cache_set(cache_key, weights)
+
+
+def _predict_production_components(
+    ohlcv: pd.DataFrame,
+    *,
+    horizon: int = PREDICTION_HORIZON,
+    ticker: str = "AAPL",
+) -> Tuple[np.ndarray, Dict[str, np.ndarray], List[pd.Timestamp], Dict[str, float]]:
+    ml_result = _forecast_ml_models(ohlcv, model_names=ML_MODELS, horizon=horizon, ticker=ticker)
+    stats_result = _forecast_statistical_models(ohlcv, horizon=horizon, ticker=ticker)
+    predictions = dict(ml_result["predictions"])
+    if "auto_arima" in stats_result["predictions"]:
+        predictions["auto_arima"] = stats_result["predictions"]["auto_arima"]
+    weights = _ensemble_weights_from_recent_cv(ohlcv, ticker)
+    ensemble = _compute_weighted_ensemble(predictions, weights)
+    return ensemble, predictions, ml_result["future_dates"], weights
+
+
+def _confidence_from_model_breakdown(model_predictions: Dict[str, np.ndarray], recent_close: float) -> float:
+    first_day = [float(preds[0]) for preds in model_predictions.values() if preds is not None and len(preds)]
+    if len(first_day) <= 1 or recent_close == 0:
+        return 85.0
+    mean_prediction = sum(first_day) / len(first_day)
+    dispersion = sum(abs(pred - mean_prediction) for pred in first_day) / len(first_day)
+    confidence = 95.0 - ((dispersion / recent_close) * 100)
+    return round(max(55.0, min(95.0, confidence)), 1)
+
+
+def linear_regression_predict(df: pd.DataFrame, days_ahead: int = PREDICTION_HORIZON) -> Optional[np.ndarray]:
+    ohlcv = _coerce_ohlcv_from_input(df)
+    if ohlcv.empty or len(ohlcv) < MIN_HISTORY_ROWS:
+        return None
+    result = _forecast_ml_models(
+        ohlcv,
+        model_names=("linear_regression",),
+        horizon=days_ahead,
+        ticker=str(df.attrs.get("ticker") or "AAPL"),
+    )
+    return result["predictions"].get("linear_regression")
+
+
+def random_forest_predict(df: pd.DataFrame, days_ahead: int = PREDICTION_HORIZON, lookback: int = 14) -> Optional[np.ndarray]:
+    _ = lookback
+    ohlcv = _coerce_ohlcv_from_input(df)
+    if ohlcv.empty or len(ohlcv) < MIN_HISTORY_ROWS:
+        return None
+    result = _forecast_ml_models(
+        ohlcv,
+        model_names=("random_forest",),
+        horizon=days_ahead,
+        ticker=str(df.attrs.get("ticker") or "AAPL"),
+    )
+    return result["predictions"].get("random_forest")
+
+
+def xgboost_predict(df: pd.DataFrame, days_ahead: int = PREDICTION_HORIZON, lookback: int = 14) -> Optional[np.ndarray]:
+    _ = lookback
+    if not XGBOOST_AVAILABLE:
+        return None
+    ohlcv = _coerce_ohlcv_from_input(df)
+    if ohlcv.empty or len(ohlcv) < MIN_HISTORY_ROWS:
+        return None
+    result = _forecast_ml_models(
+        ohlcv,
+        model_names=("xgboost",),
+        horizon=days_ahead,
+        ticker=str(df.attrs.get("ticker") or "AAPL"),
+    )
+    return result["predictions"].get("xgboost")
+
+
+def ensemble_predict(df: pd.DataFrame, days_ahead: int = PREDICTION_HORIZON) -> Tuple[Optional[np.ndarray], Dict[str, np.ndarray]]:
+    ohlcv = _coerce_ohlcv_from_input(df)
+    ticker = str(df.attrs.get("ticker") or "AAPL")
+    if ohlcv.empty or len(ohlcv) < MIN_PRODUCTION_HISTORY_ROWS:
+        return None, {}
+    ensemble, breakdown, _, _ = _predict_production_components(ohlcv, horizon=days_ahead, ticker=ticker)
+    return ensemble, breakdown
+
+
+def calculate_metrics(actual: np.ndarray, predicted: np.ndarray) -> Dict[str, float]:
+    mae = mean_absolute_error(actual, predicted)
+    rmse = math.sqrt(mean_squared_error(actual, predicted))
+    mape = mean_absolute_percentage_error(actual, predicted) * 100
+    return {
+        "mae": round(float(mae), 2),
+        "rmse": round(float(rmse), 2),
+        "mape": round(float(mape), 2),
+    }
+
+
+def _evaluation_metrics(actual: np.ndarray, predicted: np.ndarray) -> Dict[str, float]:
+    mae = mean_absolute_error(actual, predicted)
+    rmse = math.sqrt(mean_squared_error(actual, predicted))
+    mape = mean_absolute_percentage_error(actual, predicted) * 100
+    r_squared = r2_score(actual, predicted)
+    if len(predicted) > 1:
+        pred_direction = np.diff(predicted) > 0
+        actual_direction = np.diff(actual) > 0
+        directional_accuracy = float(np.mean(pred_direction == actual_direction) * 100)
+    else:
+        directional_accuracy = 0.0
+    return {
+        "mae": round(float(mae), 2),
+        "rmse": round(float(rmse), 2),
+        "mape": round(float(mape), 2),
+        "r_squared": round(float(r_squared), 4),
+        "directional_accuracy": round(directional_accuracy, 2),
+    }
+
+
+def calculate_trading_returns(predictions: np.ndarray, actuals: np.ndarray, initial_capital: float = 10000) -> Optional[Dict[str, Any]]:
+    if len(predictions) < 2:
+        return None
+
+    capital = float(initial_capital)
+    shares = 0.0
+    portfolio_values = [float(initial_capital)]
+    num_trades = 0
+
+    for index in range(len(predictions) - 1):
+        pred_return = 0.0 if predictions[index] == 0 else (predictions[index + 1] - predictions[index]) / predictions[index]
+        actual_price = float(actuals[index])
+        next_price = float(actuals[index + 1])
+
+        if pred_return > 0.005 and shares == 0 and capital > 0:
+            shares = capital / actual_price
+            capital = 0.0
+            num_trades += 1
+        elif pred_return < -0.005 and shares > 0:
+            capital = shares * actual_price
+            shares = 0.0
+            num_trades += 1
+
+        portfolio_values.append(capital + (shares * next_price))
+
+    if shares > 0:
+        capital = shares * float(actuals[-1])
+
+    total_return = ((capital - initial_capital) / initial_capital) * 100
+    buy_hold_final = (initial_capital / float(actuals[0])) * float(actuals[-1])
+    buy_hold_return = ((buy_hold_final - initial_capital) / initial_capital) * 100
+    returns_series = np.diff(portfolio_values) / np.maximum(np.array(portfolio_values[:-1]), 1e-9)
+    sharpe_ratio = (np.mean(returns_series) / np.std(returns_series)) * math.sqrt(TRADING_DAYS_PER_YEAR) if np.std(returns_series) > 0 else 0.0
+    portfolio_array = np.array(portfolio_values)
+    running_max = np.maximum.accumulate(portfolio_array)
+    drawdown = (portfolio_array - running_max) / np.maximum(running_max, 1e-9) * 100
+    max_drawdown = float(np.min(drawdown))
+
+    return {
+        "initial_capital": round(float(initial_capital), 2),
+        "final_value": round(float(capital), 2),
+        "total_return": round(float(total_return), 2),
+        "buy_hold_return": round(float(buy_hold_return), 2),
+        "outperformance": round(float(total_return - buy_hold_return), 2),
+        "sharpe_ratio": round(float(sharpe_ratio), 2),
+        "max_drawdown": round(max_drawdown, 2),
+        "num_trades": int(num_trades),
+        "portfolio_values": [round(float(value), 2) for value in portfolio_values],
+    }
+
+
+def get_prediction_snapshot(ticker: str) -> Optional[Dict[str, Any]]:
+    normalized_ticker = _normalize_ticker(ticker)
+    cache_key = ("prediction_snapshot", normalized_ticker)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    ohlcv = _load_canonical_ohlcv(normalized_ticker)
+    if ohlcv.empty or len(ohlcv) < MIN_PRODUCTION_HISTORY_ROWS:
+        return None
+    ensemble_preds, model_breakdown, future_dates, _weights = _predict_production_components(
+        ohlcv,
+        horizon=PREDICTION_PREVIEW_HORIZON,
+        ticker=normalized_ticker,
+    )
+    if ensemble_preds is None or len(ensemble_preds) == 0:
+        return None
+    recent_close = float(ohlcv["Close"].iloc[-1])
+    snapshot = {
+        "recentClose": round(recent_close, 2),
+        "recentPredicted": round(float(ensemble_preds[0]), 2),
+        "confidence": _confidence_from_model_breakdown(model_breakdown, recent_close),
+        "modelsUsed": list(model_breakdown.keys()),
+        "predictions": [
+            {"day": index + 1, "predictedClose": round(float(pred), 2), "date": future_dates[index].strftime("%Y-%m-%d")}
+            for index, pred in enumerate(ensemble_preds[:PREDICTION_PREVIEW_HORIZON])
+        ],
+    }
+    return _cache_set(cache_key, snapshot)
+
+
+def get_future_prediction_dates(df: pd.DataFrame, horizon: int) -> List[pd.Timestamp]:
+    ohlcv = _coerce_ohlcv_from_input(df)
+    if ohlcv.empty:
+        return []
+    return _future_session_dates(ohlcv.index[-1], horizon)
+
+
+def _serialize_feature_importance(feature_name: str, value: Any, impact: Any) -> Dict[str, Any]:
+    return {
+        "feature": str(feature_name),
+        "value": _clean_float(value, 4),
+        "impact": _clean_float(impact, 4),
+    }
+
+
+def _summarize_shap_explainability(
+    model_name: str,
+    model: Any,
+    feature_frame: pd.DataFrame,
+    latest_features: pd.DataFrame,
+) -> Optional[Dict[str, Any]]:
+    if feature_frame is None or feature_frame.empty or latest_features is None or latest_features.empty:
+        return None
+    try:
+        background = feature_frame.tail(min(len(feature_frame), 200))
+        if model_name == "linear_regression":
+            explainer = shap.LinearExplainer(model, background)
+        else:
+            explainer = shap.TreeExplainer(model, data=background)
+
+        background_values = np.asarray(explainer.shap_values(background))
+        latest_values = np.asarray(explainer.shap_values(latest_features))
+        if background_values.ndim == 1:
+            background_values = background_values.reshape(1, -1)
+        if latest_values.ndim == 1:
+            latest_values = latest_values.reshape(1, -1)
+
+        mean_abs = np.abs(background_values).mean(axis=0)
+        top_indices = np.argsort(mean_abs)[::-1][:5]
+        latest_row = latest_features.iloc[0]
+        latest_impacts = latest_values[0]
+        latest_indices = np.argsort(np.abs(latest_impacts))[::-1][:5]
+
+        return {
+            "global_top_features": [
+                {
+                    "feature": str(feature_frame.columns[idx]),
+                    "meanAbsImpact": _clean_float(mean_abs[idx], 4),
+                }
+                for idx in top_indices
+            ],
+            "latest_prediction_contributors": [
+                _serialize_feature_importance(
+                    feature_frame.columns[idx],
+                    latest_row.iloc[idx],
+                    latest_impacts[idx],
+                )
+                for idx in latest_indices
+            ],
+        }
+    except Exception:
+        return None
+
+
+def _build_evaluation_explainability(
+    ohlcv: pd.DataFrame,
+    ticker: str,
+    evaluation_ds: int,
+) -> Dict[str, Dict[str, Any]]:
+    long_df = _build_long_frame(ohlcv, ticker).reset_index(drop=True)
+    ml_result = _forecast_ml_models(ohlcv, model_names=ML_MODELS, horizon=PREDICTION_HORIZON, ticker=ticker)
+    feature_frame = ml_result["feature_frame"]
+    explanations: Dict[str, Dict[str, Any]] = {}
+    if feature_frame.empty:
+        return explanations
+
+    latest_index = max(0, min(len(feature_frame) - 1, int(evaluation_ds) - 2))
+    latest_features = feature_frame.iloc[[latest_index]].copy()
+
+    for model_name, model in ml_result["models"].items():
+        explainability = _summarize_shap_explainability(model_name, model, feature_frame, latest_features)
+        if explainability:
+            explanations[model_name] = explainability
+    return explanations
+
+
+def _merge_cv_frames(
+    stat_cv: pd.DataFrame,
+    ml_cv: pd.DataFrame,
+) -> pd.DataFrame:
+    merged = stat_cv[["unique_id", "ds", "cutoff", "y"]].copy()
+    for frame in (stat_cv, ml_cv):
+        for column in frame.columns:
+            if column in {"unique_id", "ds", "cutoff", "y"}:
+                continue
+            merged[column] = frame[column]
+    return merged.sort_values("ds").reset_index(drop=True)
+
+
+def _prepare_cv_frames(
+    ticker: str,
+    *,
+    ohlcv: pd.DataFrame,
+    test_days: int,
+    retrain_frequency: int,
+    max_train_rows: Optional[int],
+) -> pd.DataFrame:
+    long_df = _build_long_frame(ohlcv, ticker)
+    if len(long_df) <= max(test_days + 30, 60):
+        raise ValueError("Insufficient data for evaluation.")
+
+    n_windows = min(test_days, len(long_df) - 30)
+    if n_windows < 5:
+        raise ValueError("Insufficient backtest windows.")
+
+    input_size = min(max_train_rows, len(long_df) - 1) if max_train_rows else None
+
+    stats_cv = _build_statsforecast().cross_validation(
+        h=1,
+        df=long_df[["unique_id", "ds", "y"]].reset_index(drop=True),
+        n_windows=n_windows,
+        step_size=1,
+        refit=max(1, retrain_frequency),
+        input_size=input_size,
+    )
+
+    ml_models = _build_ml_models()
+    ml_fcst = _build_mlforecast(ml_models)
+    ml_cv = ml_fcst.cross_validation(
+        df=long_df.reset_index(drop=True),
+        n_windows=n_windows,
+        h=1,
+        step_size=1,
+        refit=max(1, retrain_frequency),
+        static_features=[],
+        input_size=input_size,
+    )
+    return _merge_cv_frames(stats_cv, ml_cv)
+
+
+def rolling_window_backtest(
+    ticker: str,
+    test_days: int = 60,
+    retrain_frequency: int = 5,
+    include_selective: bool = False,
+    include_selector_variants: bool = False,
+    fast_mode: bool = True,
+    max_train_rows: Optional[int] = None,
+    include_explanations: Optional[bool] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_ticker = _normalize_ticker(ticker)
+    if include_explanations is None:
+        include_explanations = not fast_mode
+
+    cache_key = (
+        "rolling_backtest",
+        normalized_ticker,
+        int(test_days),
+        int(retrain_frequency),
+        bool(include_selective),
+        bool(include_selector_variants),
+        bool(fast_mode),
+        int(max_train_rows) if max_train_rows else None,
+        bool(include_explanations),
+    )
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    ohlcv = _load_canonical_ohlcv(normalized_ticker)
+    if ohlcv.empty or len(ohlcv) < 120:
+        return None
+
+    merged_cv = _prepare_cv_frames(
+        normalized_ticker,
+        ohlcv=ohlcv,
+        test_days=test_days,
+        retrain_frequency=retrain_frequency,
+        max_train_rows=max_train_rows,
+    )
+
+    actuals = merged_cv["y"].to_numpy(dtype=float)
+    date_lookup = {
+        index + 1: pd.to_datetime(session_date)
+        for index, session_date in enumerate(pd.to_datetime(ohlcv.index).tz_localize(None))
+    }
+    dates = [date_lookup[int(ds)].strftime("%Y-%m-%d") for ds in merged_cv["ds"]]
+
+    model_predictions = {
+        model_name: merged_cv[model_name].to_numpy(dtype=float)
+        for model_name in BENCHMARK_MODELS + ML_MODELS
+        if model_name in merged_cv.columns
+    }
+    ensemble_weights = _ensemble_weights_from_recent_cv(ohlcv, normalized_ticker)
+    model_predictions["ensemble"] = _compute_weighted_ensemble(model_predictions, ensemble_weights)
+
+    results = {
+        "ticker": normalized_ticker,
+        "featureSpecVersion": FEATURE_SPEC_VERSION,
+        "test_period": {
+            "start_date": dates[0],
+            "end_date": dates[-1],
+            "days": len(dates),
+        },
+        "dates": dates,
+        "actuals": [round(float(value), 2) for value in actuals],
+        "models": {},
+        "evaluationOptions": {
+            "fastMode": bool(fast_mode),
+            "includeSelective": bool(include_selective),
+            "includeSelectorVariants": bool(include_selector_variants),
+            "retrainFrequency": int(retrain_frequency),
+            "maxTrainRows": int(max_train_rows) if max_train_rows else None,
+            "includeExplanations": bool(include_explanations),
+        },
+    }
+
+    explainability = (
+        _build_evaluation_explainability(ohlcv, normalized_ticker, int(merged_cv["ds"].iloc[-1]))
+        if include_explanations
+        else {}
+    )
+
+    for model_name, predictions in model_predictions.items():
+        if predictions is None or len(predictions) == 0:
+            continue
+        payload = {
+            "predictions": [round(float(prediction), 2) for prediction in predictions],
+            "metrics": _evaluation_metrics(actuals, predictions),
+        }
+        if model_name in explainability:
+            payload["explainability"] = explainability[model_name]
+        results["models"][model_name] = payload
+
+    results["returns"] = calculate_trading_returns(
+        np.asarray(results["models"]["ensemble"]["predictions"], dtype=float),
+        actuals,
+    )
+    results["best_model"] = min(
+        results["models"].items(),
+        key=lambda item: item[1]["metrics"]["mape"],
+    )[0]
+    return _cache_set(cache_key, results)

--- a/backend/professional_evaluation.py
+++ b/backend/professional_evaluation.py
@@ -1,387 +1,42 @@
 """
-Professional-grade ML model evaluation system
-Implements docs/backend/DATA_SPECS.md with 42 fixed features and rolling window backtesting
+Compatibility wrappers for the upgraded prediction stack.
+
+The legacy /evaluate route and a few docs/tests still import from this module, so
+the implementation now delegates to prediction_service.
 """
-import numpy as np
-import pandas as pd
-from sklearn.ensemble import RandomForestRegressor
-from sklearn.linear_model import LinearRegression
-from sklearn.metrics import mean_absolute_error, mean_squared_error, mean_absolute_percentage_error, r2_score
-import warnings
-warnings.filterwarnings('ignore')
 
-# Try XGBoost
-try:
-    import xgboost as xgb
-    XGBOOST_AVAILABLE = True
-except:
-    XGBOOST_AVAILABLE = False
+from __future__ import annotations
 
-from data_fetcher import prepare_data_for_ml
+from typing import Any, Dict, Optional
 
+from prediction_service import (
+    FEATURE_SPEC_VERSION,
+    calculate_trading_returns,
+    rolling_window_backtest,
+)
 
-def create_fixed_features(df, lookback=30):
-    """
-    Create EXACTLY 42 features (always consistent)
-    
-    Features:
-    - 30 lagged prices
-    - 4 moving averages (5, 10, 20, 30 day)
-    - 3 volatility measures (5, 10, 20 day std)
-    - 3 momentum indicators (1, 5, 20 day returns)
-    - 2 volume ratios (5, 20 day)
-    
-    Total: 42 features
-    """
-    df = df.copy()
-    features = []
-    
-    # 1. Lagged Prices (30 features)
-    for i in range(1, lookback + 1):
-        col_name = f'lag_{i}'
-        df[col_name] = df['Close'].shift(i)
-        features.append(col_name)
-    
-    # 2. Moving Averages (4 features)
-    for window in [5, 10, 20, 30]:
-        col_name = f'MA_{window}'
-        df[col_name] = df['Close'].rolling(window=window, min_periods=1).mean()
-        features.append(col_name)
-    
-    # 3. Volatility (3 features)
-    for window in [5, 10, 20]:
-        col_name = f'std_{window}'
-        df[col_name] = df['Close'].rolling(window=window, min_periods=1).std()
-        features.append(col_name)
-    
-    # 4. Momentum / Returns (3 features)
-    for window in [1, 5, 20]:
-        col_name = f'return_{window}day'
-        df[col_name] = df['Close'].pct_change(periods=window)
-        features.append(col_name)
-    
-    # 5. Volume Ratios (2 features)
-    for window in [5, 20]:
-        col_name = f'volume_ratio_{window}'
-        avg_volume = df['Volume'].rolling(window=window, min_periods=1).mean()
-        df[col_name] = df['Volume'] / avg_volume
-        df[col_name] = df[col_name].replace([np.inf, -np.inf], 1.0)
-        features.append(col_name)
-    
-    # Fill NaN values
-    df[features] = df[features].fillna(method='ffill').fillna(method='bfill').fillna(0)
-    
-    assert len(features) == 42, f"Expected 42 features, got {len(features)}"
-    
-    return df, features
+__all__ = [
+    "FEATURE_SPEC_VERSION",
+    "calculate_trading_returns",
+    "rolling_window_backtest",
+]
 
 
-def train_models(X_train, y_train):
-    """
-    Train all 3 models: RandomForest, XGBoost, LinearRegression
-    
-    Returns dict of trained models
-    """
-    models = {}
-    
-    # Random Forest
-    rf = RandomForestRegressor(
-        n_estimators=100,
-        max_depth=10,
-        min_samples_split=5,
-        min_samples_leaf=2,
-        random_state=42,
-        n_jobs=-1
-    )
-    rf.fit(X_train, y_train)
-    models['random_forest'] = rf
-    
-    # XGBoost
-    if XGBOOST_AVAILABLE:
-        xgb_model = xgb.XGBRegressor(
-            n_estimators=100,
-            max_depth=5,
-            learning_rate=0.1,
-            subsample=0.8,
-            colsample_bytree=0.8,
-            random_state=42,
-            n_jobs=-1
-        )
-        xgb_model.fit(X_train, y_train)
-        models['xgboost'] = xgb_model
-    
-    # Linear Regression
-    lr = LinearRegression()
-    lr.fit(X_train, y_train)
-    models['linear_regression'] = lr
-    
-    return models
-
-
-def rolling_window_backtest(ticker, test_days=60, retrain_frequency=5):
-    """
-    Professional rolling window backtesting
-    
-    Process:
-    1. Fetch 2 years of data
-    2. Create 42 fixed features
-    3. Split: train on first 250+ days, test on last test_days
-    4. Retrain every retrain_frequency days
-    5. Predict 1 day ahead
-    6. Calculate metrics
-    
-    Returns comprehensive evaluation results
-    """
-    print(f"\n{'='*60}")
-    print(f"PROFESSIONAL EVALUATION: {ticker}")
-    print(f"{'='*60}\n")
-    
-    # 1. Fetch and prepare data
-    print(f"[1/6] Fetching data...")
-    df_raw = prepare_data_for_ml(ticker, min_days=280)
-    
-    if df_raw is None or len(df_raw) < 280:
-        return None
-    
-    # 2. Create fixed 42 features
-    print(f"[2/6] Engineering 42 features...")
-    df, feature_cols = create_fixed_features(df_raw, lookback=30)
-    
-    print(f"  ✓ Features: {len(feature_cols)}")
-    print(f"  ✓ Data shape: {df.shape}")
-    
-    # 3. Define train/test split
-    test_start_idx = len(df) - test_days
-    min_train_days = 250
-    
-    if test_start_idx < min_train_days:
-        print(f"  ✗ Insufficient data: need {min_train_days} train days")
-        return None
-    
-    print(f"  ✓ Train: days 1-{test_start_idx} ({test_start_idx} days)")
-    print(f"  ✓ Test: days {test_start_idx}-{len(df)} ({test_days} days)")
-    
-    # 4. Rolling window predictions
-    print(f"[3/6] Running rolling window backtest...")
-    
-    predictions = {
-        'random_forest': [],
-        'xgboost': [] if XGBOOST_AVAILABLE else None,
-        'linear_regression': [],
-        'ensemble': []
-    }
-    actuals = []
-    dates = []
-    
-    models = None
-    last_train_idx = None
-    
-    for i in range(test_start_idx, len(df) - 1):
-        # Retrain models every retrain_frequency days or first iteration
-        if models is None or (i - test_start_idx) % retrain_frequency == 0:
-            train_data = df.iloc[:i]
-            X_train = train_data[feature_cols].values
-            y_train = train_data['Close'].values
-            
-            print(f"  → Training at day {i} ({len(X_train)} samples)...")
-            models = train_models(X_train, y_train)
-            last_train_idx = i
-        
-        # Prepare test sample (1-day ahead prediction)
-        X_test = df.iloc[i][feature_cols].values.reshape(1, -1)
-        y_actual = df.iloc[i + 1]['Close']
-        
-        # Predict with each model
-        pred_rf = models['random_forest'].predict(X_test)[0]
-        predictions['random_forest'].append(pred_rf)
-        
-        if XGBOOST_AVAILABLE and 'xgboost' in models:
-            pred_xgb = models['xgboost'].predict(X_test)[0]
-            predictions['xgboost'].append(pred_xgb)
-        
-        pred_lr = models['linear_regression'].predict(X_test)[0]
-        predictions['linear_regression'].append(pred_lr)
-        
-        # Ensemble (average)
-        ensemble_preds = [pred_rf, pred_lr]
-        if XGBOOST_AVAILABLE and 'xgboost' in models:
-            ensemble_preds.append(pred_xgb)
-        pred_ensemble = np.mean(ensemble_preds)
-        predictions['ensemble'].append(pred_ensemble)
-        
-        # Store actual
-        actuals.append(y_actual)
-        dates.append(df.index[i + 1])
-    
-    print(f"  ✓ Generated {len(actuals)} predictions")
-    
-    # 5. Calculate metrics
-    print(f"[4/6] Calculating metrics...")
-    actuals_array = np.array(actuals)
-    
-    results = {
-        'ticker': ticker,
-        'test_period': {
-            'start_date': dates[0].strftime('%Y-%m-%d'),
-            'end_date': dates[-1].strftime('%Y-%m-%d'),
-            'days': len(dates)
-        },
-        'dates': [d.strftime('%Y-%m-%d') for d in dates],
-        'actuals': [float(a) for a in actuals],
-        'models': {}
-    }
-    
-    for model_name, preds in predictions.items():
-        if preds is None or len(preds) == 0:
-            continue
-        
-        preds_array = np.array(preds)
-        
-        # Accuracy metrics
-        mae = mean_absolute_error(actuals_array, preds_array)
-        rmse = np.sqrt(mean_squared_error(actuals_array, preds_array))
-        mape = mean_absolute_percentage_error(actuals_array, preds_array) * 100
-        r2 = r2_score(actuals_array, preds_array)
-        
-        # Directional accuracy
-        if len(preds_array) > 1:
-            pred_direction = np.diff(preds_array) > 0
-            actual_direction = np.diff(actuals_array) > 0
-            dir_acc = np.mean(pred_direction == actual_direction) * 100
-        else:
-            dir_acc = 0
-        
-        results['models'][model_name] = {
-            'predictions': [float(p) for p in preds],
-            'metrics': {
-                'mae': round(float(mae), 2),
-                'rmse': round(float(rmse), 2),
-                'mape': round(float(mape), 2),
-                'r_squared': round(float(r2), 4),
-                'directional_accuracy': round(float(dir_acc), 2)
-            }
-        }
-        
-        print(f"  ✓ {model_name}: MAE=${mae:.2f}, MAPE={mape:.2f}%, R²={r2:.4f}")
-    
-    # 6. Calculate trading returns
-    print(f"[5/6] Calculating trading returns...")
-    ensemble_preds = np.array(predictions['ensemble'])
-    returns_data = calculate_trading_returns(ensemble_preds, actuals_array)
-    results['returns'] = returns_data
-    
-    # Best model
-    best_by_mape = min(
-        results['models'].items(),
-        key=lambda x: x[1]['metrics']['mape']
-    )[0]
-    results['best_model'] = best_by_mape
-    
-    print(f"[6/6] Complete!")
-    print(f"\n{'='*60}")
-    print(f"BEST MODEL: {best_by_mape.upper()}")
-    print(f"{'='*60}\n")
-    
-    return results
-
-
-def calculate_trading_returns(predictions, actuals, initial_capital=10000):
-    """
-    Calculate returns from a simple trading strategy
-    
-    Strategy: Buy if predict >0.5% increase, sell if predict >0.5% decrease
-    """
-    if len(predictions) < 2:
-        return None
-    
-    capital = initial_capital
-    shares = 0
-    portfolio_values = [initial_capital]
-    num_trades = 0
-    
-    for i in range(len(predictions) - 1):
-        pred_return = (predictions[i + 1] - predictions[i]) / predictions[i]
-        actual_price = actuals[i]
-        next_price = actuals[i + 1]
-        
-        # Buy signal
-        if pred_return > 0.005 and shares == 0 and capital > 0:
-            shares = capital / actual_price
-            capital = 0
-            num_trades += 1
-        
-        # Sell signal
-        elif pred_return < -0.005 and shares > 0:
-            capital = shares * actual_price
-            shares = 0
-            num_trades += 1
-        
-        # Portfolio value
-        portfolio_value = capital + (shares * next_price)
-        portfolio_values.append(portfolio_value)
-    
-    # Final liquidation
-    if shares > 0:
-        capital = shares * actuals[-1]
-    
-    total_return = ((capital - initial_capital) / initial_capital) * 100
-    
-    # Buy and hold
-    buy_hold_final = (initial_capital / actuals[0]) * actuals[-1]
-    buy_hold_return = ((buy_hold_final - initial_capital) / initial_capital) * 100
-    
-    # Sharpe ratio (simplified)
-    returns_series = np.diff(portfolio_values) / portfolio_values[:-1]
-    sharpe = (np.mean(returns_series) / np.std(returns_series)) * np.sqrt(252) if np.std(returns_series) > 0 else 0
-    
-    # Max drawdown
-    portfolio_array = np.array(portfolio_values)
-    running_max = np.maximum.accumulate(portfolio_array)
-    drawdown = (portfolio_array - running_max) / running_max * 100
-    max_drawdown = np.min(drawdown)
-    
+def describe_feature_spec() -> Dict[str, Any]:
     return {
-        'initial_capital': initial_capital,
-        'final_value': round(float(capital), 2),
-        'total_return': round(float(total_return), 2),
-        'buy_hold_return': round(float(buy_hold_return), 2),
-        'outperformance': round(float(total_return - buy_hold_return), 2),
-        'sharpe_ratio': round(float(sharpe), 2),
-        'max_drawdown': round(float(max_drawdown), 2),
-        'num_trades': num_trades,
-        'portfolio_values': [round(float(v), 2) for v in portfolio_values]
+        "version": FEATURE_SPEC_VERSION,
+        "families": [
+            "lag features",
+            "rolling trend features",
+            "rolling volatility features",
+            "momentum features",
+            "volume-derived features",
+            "session calendar features",
+        ],
     }
 
 
 if __name__ == "__main__":
-    # Test the professional evaluation
-    result = rolling_window_backtest('AAPL', test_days=60, retrain_frequency=5)
-    
+    result: Optional[Dict[str, Any]] = rolling_window_backtest("AAPL", test_days=60, retrain_frequency=5)
     if result:
-        print("\n" + "="*60)
-        print("RESULTS SUMMARY")
-        print("="*60)
-        print(f"\nTicker: {result['ticker']}")
-        print(f"Period: {result['test_period']['start_date']} to {result['test_period']['end_date']}")
-        print(f"Days tested: {result['test_period']['days']}")
-        
-        print("\nModel Performance:")
-        for model_name, data in result['models'].items():
-            metrics = data['metrics']
-            print(f"\n{model_name.upper()}:")
-            print(f"  MAE:  ${metrics['mae']}")
-            print(f"  RMSE: ${metrics['rmse']}")
-            print(f"  MAPE: {metrics['mape']}%")
-            print(f"  R²:   {metrics['r_squared']}")
-            print(f"  Dir Acc: {metrics['directional_accuracy']}%")
-        
-        print(f"\nTrading Performance (Ensemble):")
-        returns = result['returns']
-        print(f"  Initial: ${returns['initial_capital']}")
-        print(f"  Final:   ${returns['final_value']}")
-        print(f"  Return:  {returns['total_return']}%")
-        print(f"  B&H:     {returns['buy_hold_return']}%")
-        print(f"  Outperf: {returns['outperformance']}%")
-        print(f"  Sharpe:  {returns['sharpe_ratio']}")
-        print(f"  Max DD:  {returns['max_drawdown']}%")
-        print(f"  Trades:  {returns['num_trades']}")
+        print(result["ticker"], result["best_model"], result.get("featureSpecVersion"))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,6 +32,7 @@ Jinja2==3.1.6
 joblib==1.5.2
 lxml==6.0.2
 MarkupSafe==3.0.3
+mlforecast==1.0.31
 msgpack==1.0.3
 multidict==6.7.0
 multitasking==0.0.12
@@ -62,7 +63,9 @@ soupsieve==2.8
 sseclient-py==1.8.0
 statsmodels==0.14.5
 schedule==1.2.2
+shap==0.49.1
 SQLAlchemy==2.0.44
+statsforecast==2.0.3
 stripe==15.0.0
 alembic==1.14.1
 threadpoolctl==3.6.0

--- a/backend/tests/test_chart_prediction_append.py
+++ b/backend/tests/test_chart_prediction_append.py
@@ -34,6 +34,7 @@ class ChartPredictionAppendTests(unittest.TestCase):
             "ticker_cls": backend_api.yf.Ticker,
             "create_dataset": backend_api.create_dataset,
             "ensemble_predict": backend_api.ensemble_predict,
+            "future_prediction_dates": backend_api.prediction_service.get_future_prediction_dates,
         }
         backend_api.app.testing = True
         self.client = backend_api.app.test_client()
@@ -49,11 +50,22 @@ class ChartPredictionAppendTests(unittest.TestCase):
                 {"linear_regression": np.array([121.0, 122.0, 123.0, 124.0, 125.0, 126.0])},
             )
         )
+        backend_api.prediction_service.get_future_prediction_dates = (
+            lambda df, horizon: list(pd.to_datetime([
+                "2025-05-01",
+                "2025-05-02",
+                "2025-05-05",
+                "2025-05-06",
+                "2025-05-07",
+                "2025-05-08",
+            ]))[:horizon]
+        )
 
     def tearDown(self):
         backend_api.yf.Ticker = self.original["ticker_cls"]
         backend_api.create_dataset = self.original["create_dataset"]
         backend_api.ensemble_predict = self.original["ensemble_predict"]
+        backend_api.prediction_service.get_future_prediction_dates = self.original["future_prediction_dates"]
 
     def test_chart_endpoint_appends_prediction_rows(self):
         resp = self.client.get("/chart/AAPL?period=1mo")
@@ -61,7 +73,7 @@ class ChartPredictionAppendTests(unittest.TestCase):
 
         payload = resp.get_json()
         self.assertEqual(len(payload), 9)
-        self.assertEqual(payload[-1]["date"], "2025-05-06 00:00:00")
+        self.assertEqual(payload[-1]["date"], "2025-05-08 00:00:00")
         self.assertEqual(payload[-1]["close"], 126.0)
         self.assertIsNone(payload[-1]["open"])
         self.assertIsNone(payload[-1]["volume"])

--- a/backend/tests/test_prediction_service.py
+++ b/backend/tests/test_prediction_service.py
@@ -1,0 +1,159 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import prediction_service
+
+
+def _sample_ohlcv(rows=220):
+    index = pd.bdate_range("2025-01-02", periods=rows)
+    close = np.linspace(100.0, 140.0, rows)
+    return pd.DataFrame(
+        {
+            "Open": close - 0.5,
+            "High": close + 1.0,
+            "Low": close - 1.0,
+            "Close": close,
+            "Volume": np.linspace(1_000_000, 1_500_000, rows),
+        },
+        index=index,
+    )
+
+
+class PredictionServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.original = {
+            "load_canonical_ohlcv": prediction_service._load_canonical_ohlcv,
+            "predict_components": prediction_service._predict_production_components,
+            "prepare_cv_frames": prediction_service._prepare_cv_frames,
+            "ensemble_weights": prediction_service._ensemble_weights_from_recent_cv,
+            "build_explainability": prediction_service._build_evaluation_explainability,
+            "build_long_frame": prediction_service._build_long_frame,
+            "build_statsforecast": prediction_service._build_statsforecast,
+            "build_mlforecast": prediction_service._build_mlforecast,
+        }
+        prediction_service._CACHE.clear()
+
+    def tearDown(self):
+        prediction_service._load_canonical_ohlcv = self.original["load_canonical_ohlcv"]
+        prediction_service._predict_production_components = self.original["predict_components"]
+        prediction_service._prepare_cv_frames = self.original["prepare_cv_frames"]
+        prediction_service._ensemble_weights_from_recent_cv = self.original["ensemble_weights"]
+        prediction_service._build_evaluation_explainability = self.original["build_explainability"]
+        prediction_service._build_long_frame = self.original["build_long_frame"]
+        prediction_service._build_statsforecast = self.original["build_statsforecast"]
+        prediction_service._build_mlforecast = self.original["build_mlforecast"]
+        prediction_service._CACHE.clear()
+
+    def test_prediction_snapshot_preserves_contract(self):
+        ohlcv = _sample_ohlcv()
+        prediction_service._load_canonical_ohlcv = lambda ticker: ohlcv.copy()
+        prediction_service._predict_production_components = lambda ohlcv_arg, horizon, ticker: (
+            np.array([141.25, 141.8, 142.4]),
+            {
+                "auto_arima": np.array([141.0, 141.6, 142.1]),
+                "linear_regression": np.array([141.4, 141.9, 142.5]),
+                "random_forest": np.array([141.2, 141.7, 142.2]),
+            },
+            [pd.Timestamp("2026-04-03"), pd.Timestamp("2026-04-06"), pd.Timestamp("2026-04-07")],
+            {"auto_arima": 0.3, "linear_regression": 0.35, "random_forest": 0.35},
+        )
+
+        snapshot = prediction_service.get_prediction_snapshot("AAPL")
+
+        self.assertEqual(snapshot["recentClose"], 140.0)
+        self.assertEqual(snapshot["recentPredicted"], 141.25)
+        self.assertEqual(snapshot["modelsUsed"], ["auto_arima", "linear_regression", "random_forest"])
+        self.assertEqual(len(snapshot["predictions"]), 3)
+        self.assertEqual(snapshot["predictions"][0]["date"], "2026-04-03")
+        self.assertIn("confidence", snapshot)
+
+    def test_ensemble_weights_fallback_to_equal_weight_when_cv_fails(self):
+        ohlcv = _sample_ohlcv()
+        prediction_service._build_long_frame = lambda ohlcv_arg, ticker: pd.DataFrame(
+            {
+                "unique_id": ["AAPL"] * len(ohlcv),
+                "ds": np.arange(1, len(ohlcv) + 1),
+                "y": np.linspace(100.0, 140.0, len(ohlcv)),
+            }
+        )
+
+        class _BrokenStatsForecast:
+            def cross_validation(self, *args, **kwargs):
+                raise RuntimeError("stats unavailable")
+
+        class _BrokenMLForecast:
+            def cross_validation(self, *args, **kwargs):
+                raise RuntimeError("ml unavailable")
+
+        prediction_service._build_statsforecast = lambda: _BrokenStatsForecast()
+        prediction_service._build_mlforecast = lambda models: _BrokenMLForecast()
+
+        weights = prediction_service._ensemble_weights_from_recent_cv(ohlcv, "AAPL")
+
+        self.assertAlmostEqual(sum(weights.values()), 1.0, places=6)
+        expected_models = 4 if prediction_service.XGBOOST_AVAILABLE else 3
+        self.assertEqual(len(weights), expected_models)
+        first_weight = next(iter(weights.values()))
+        for value in weights.values():
+            self.assertAlmostEqual(value, first_weight, places=6)
+
+    def test_rolling_window_backtest_returns_feature_spec_and_explainability(self):
+        ohlcv = _sample_ohlcv()
+        merged_cv = pd.DataFrame(
+            {
+                "unique_id": ["AAPL"] * 6,
+                "ds": [180, 181, 182, 183, 184, 185],
+                "cutoff": [179, 180, 181, 182, 183, 184],
+                "y": [131.0, 132.0, 133.0, 134.0, 135.0, 136.0],
+                "naive": [130.8, 131.6, 132.7, 133.8, 134.7, 135.8],
+                "seasonal_naive_5": [130.5, 131.8, 132.9, 133.6, 134.9, 136.1],
+                "auto_arima": [131.2, 132.2, 133.1, 134.1, 135.2, 136.2],
+                "linear_regression": [131.1, 132.1, 133.2, 134.2, 135.1, 136.3],
+                "random_forest": [131.0, 132.3, 133.4, 134.4, 135.5, 136.4],
+                "xgboost": [131.3, 132.4, 133.3, 134.5, 135.4, 136.5],
+            }
+        )
+
+        prediction_service._load_canonical_ohlcv = lambda ticker: ohlcv.copy()
+        prediction_service._prepare_cv_frames = lambda *args, **kwargs: merged_cv.copy()
+        prediction_service._ensemble_weights_from_recent_cv = lambda ohlcv_arg, ticker: {
+            "auto_arima": 0.25,
+            "linear_regression": 0.25,
+            "random_forest": 0.25,
+            "xgboost": 0.25,
+        }
+        prediction_service._build_evaluation_explainability = lambda *args, **kwargs: {
+            "linear_regression": {
+                "global_top_features": [{"feature": "lag1", "meanAbsImpact": 1.2345}],
+                "latest_prediction_contributors": [{"feature": "lag1", "value": 135.0, "impact": 0.5678}],
+            }
+        }
+
+        result = prediction_service.rolling_window_backtest(
+            "AAPL",
+            test_days=6,
+            retrain_frequency=2,
+            fast_mode=False,
+            include_explanations=True,
+        )
+
+        self.assertEqual(result["ticker"], "AAPL")
+        self.assertEqual(result["featureSpecVersion"], prediction_service.FEATURE_SPEC_VERSION)
+        self.assertEqual(result["evaluationOptions"]["includeExplanations"], True)
+        self.assertIn("ensemble", result["models"])
+        self.assertIn("linear_regression", result["models"])
+        self.assertIn("explainability", result["models"]["linear_regression"])
+        self.assertNotIn("explainability", result["models"]["ensemble"])
+        self.assertEqual(len(result["dates"]), 6)
+        self.assertEqual(result["returns"]["initial_capital"], 10000.0)
+        self.assertIn(result["best_model"], result["models"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_prediction_stack_routes.py
+++ b/backend/tests/test_prediction_stack_routes.py
@@ -1,0 +1,133 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import api as backend_api
+
+
+class _DummyTicker:
+    def __init__(self, ticker):
+        self.info = {"symbol": ticker, "longName": "Prediction Route Inc"}
+
+
+class PredictionStackRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.original = {
+            "ticker_cls": backend_api.yf.Ticker,
+            "create_dataset": backend_api.create_dataset,
+            "linear_regression_predict": backend_api.linear_regression_predict,
+            "ensemble_predict": backend_api.ensemble_predict,
+            "rolling_window_backtest": backend_api.rolling_window_backtest,
+            "future_prediction_dates": backend_api.prediction_service.get_future_prediction_dates,
+        }
+        backend_api.app.testing = True
+        self.client = backend_api.app.test_client()
+
+        index = pd.bdate_range("2025-01-02", periods=180)
+        self.df = pd.DataFrame({"Close": np.linspace(100.0, 140.0, len(index))}, index=index)
+        self.future_dates = [
+            pd.Timestamp("2026-04-03"),
+            pd.Timestamp("2026-04-06"),
+            pd.Timestamp("2026-04-07"),
+            pd.Timestamp("2026-04-08"),
+            pd.Timestamp("2026-04-09"),
+            pd.Timestamp("2026-04-10"),
+            pd.Timestamp("2026-04-13"),
+        ]
+
+        backend_api.yf.Ticker = _DummyTicker
+        backend_api.create_dataset = lambda ticker, period="1y": self.df.copy()
+        backend_api.linear_regression_predict = lambda df, days_ahead=7: np.array(
+            [141.0, 141.6, 142.1, 142.7, 143.2, 143.9, 144.4][:days_ahead]
+        )
+        backend_api.ensemble_predict = lambda df, days_ahead=7: (
+            np.array([141.2, 141.9, 142.5, 143.0, 143.4, 143.8, 144.2][:days_ahead]),
+            {
+                "auto_arima": np.array([141.1, 141.8, 142.4, 142.9, 143.2, 143.7, 144.0][:days_ahead]),
+                "linear_regression": np.array([141.0, 141.6, 142.1, 142.7, 143.2, 143.9, 144.4][:days_ahead]),
+                "random_forest": np.array([141.3, 142.0, 142.6, 143.1, 143.5, 143.8, 144.3][:days_ahead]),
+            },
+        )
+        backend_api.prediction_service.get_future_prediction_dates = lambda df, horizon: self.future_dates[:horizon]
+
+    def tearDown(self):
+        backend_api.yf.Ticker = self.original["ticker_cls"]
+        backend_api.create_dataset = self.original["create_dataset"]
+        backend_api.linear_regression_predict = self.original["linear_regression_predict"]
+        backend_api.ensemble_predict = self.original["ensemble_predict"]
+        backend_api.rolling_window_backtest = self.original["rolling_window_backtest"]
+        backend_api.prediction_service.get_future_prediction_dates = self.original["future_prediction_dates"]
+
+    def test_single_model_prediction_route_uses_trading_session_dates(self):
+        response = self.client.get("/predict/LinReg/AAPL")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["predictions"][0]["date"], "2026-04-03")
+        self.assertEqual(len(payload["predictions"]), 7)
+
+    def test_ensemble_prediction_route_keeps_contract_with_new_models(self):
+        response = self.client.get("/predict/ensemble/AAPL")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["symbol"], "AAPL")
+        self.assertIn("auto_arima", payload["modelsUsed"])
+        self.assertIn("confidence", payload)
+        self.assertEqual(payload["predictions"][-1]["date"], "2026-04-13")
+
+    def test_evaluate_route_forwards_include_explanations(self):
+        captured = {}
+
+        def _fake_backtest(ticker, **kwargs):
+            captured["ticker"] = ticker
+            captured.update(kwargs)
+            return {
+                "ticker": ticker,
+                "featureSpecVersion": "prediction-stack-v2",
+                "test_period": {"start_date": "2026-01-01", "end_date": "2026-01-10", "days": 6},
+                "dates": ["2026-01-01", "2026-01-02"],
+                "actuals": [100.0, 101.0],
+                "models": {
+                    "ensemble": {
+                        "predictions": [100.5, 101.2],
+                        "metrics": {
+                            "mae": 1.0,
+                            "rmse": 1.2,
+                            "mape": 1.1,
+                            "r_squared": 0.8,
+                            "directional_accuracy": 50.0,
+                        },
+                    }
+                },
+                "evaluationOptions": {"includeExplanations": kwargs.get("include_explanations")},
+                "returns": {
+                    "initial_capital": 10000.0,
+                    "final_value": 10100.0,
+                    "total_return": 1.0,
+                    "buy_hold_return": 0.8,
+                    "outperformance": 0.2,
+                    "sharpe_ratio": 1.0,
+                    "max_drawdown": -1.0,
+                    "num_trades": 1,
+                    "portfolio_values": [10000.0, 10100.0],
+                },
+                "best_model": "ensemble",
+            }
+
+        backend_api.rolling_window_backtest = _fake_backtest
+
+        response = self.client.get("/evaluate/AAPL?fast_mode=false&include_explanations=true&test_days=30")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(captured["ticker"], "AAPL")
+        self.assertEqual(captured["test_days"], 30)
+        self.assertEqual(captured["fast_mode"], False)
+        self.assertEqual(captured["include_explanations"], True)
+        self.assertEqual(response.get_json()["featureSpecVersion"], "prediction-stack-v2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/backend/API_DOCUMENTATION.md
+++ b/docs/backend/API_DOCUMENTATION.md
@@ -94,15 +94,16 @@ GET /chart/<ticker>
 
 ## 🔮 Predictions
 
-### Predict Stock Price (Linear Regression)
+### Predict Stock Price (Single Model)
 
 ```http
-GET /predict/<ticker>
+GET /predict/<model>/<ticker>
 ```
 
-**Description:** Generate 7-day price prediction using Linear Regression model
+**Description:** Generate a 7 trading-session price prediction for a single model. Supported classical routes are `LinReg`, `RandomForest`, and `XGBoost`. Legacy explicit routes `LSTM` and `Transformer` remain available.
 
 **Parameters:**
+- `model` (string, path, required): Model label used by the UI route
 - `ticker` (string, path, required): Stock ticker symbol
 
 **Response:** `200 OK`
@@ -134,7 +135,7 @@ GET /predict/<ticker>
 GET /predict/ensemble/<ticker>
 ```
 
-**Description:** Generate enhanced 7-day prediction using ensemble of Random Forest, XGBoost, and Linear Regression
+**Description:** Generate a 7 trading-session ensemble forecast using AutoARIMA, Linear Regression, Random Forest, and XGBoost.
 
 **Parameters:**
 - `ticker` (string, path, required): Stock ticker symbol
@@ -144,21 +145,24 @@ GET /predict/ensemble/<ticker>
 {
   "symbol": "AAPL",
   "companyName": "Apple Inc.",
-  "currentPrice": 175.43,
+  "recentDate": "2024-11-14",
+  "recentClose": 175.43,
+  "recentPredicted": 176.49,
   "predictions": [
     {
       "date": "2024-11-15",
-      "linear": 176.12,
-      "randomForest": 176.45,
-      "xgboost": 176.89,
-      "ensemble": 176.49
+      "predictedClose": 176.49
     }
   ],
-  "metrics": {
-    "mae": 2.34,
-    "rmse": 3.12,
-    "r2": 0.89
-  }
+  "modelBreakdown": {
+    "auto_arima": [176.10, 176.25],
+    "linear_regression": [176.12, 176.30],
+    "random_forest": [176.45, 176.82],
+    "xgboost": [176.89, 177.04]
+  },
+  "modelsUsed": ["auto_arima", "linear_regression", "random_forest", "xgboost"],
+  "ensembleMethod": "weighted_average",
+  "confidence": 87.6
 }
 ```
 
@@ -172,40 +176,63 @@ GET /predict/ensemble/<ticker>
 GET /evaluate/<ticker>?test_days=60&retrain_frequency=5
 ```
 
-**Description:** Professional rolling window backtesting with model retraining
+**Description:** Professional rolling-window backtesting with trading-session-aware horizons, a versioned feature spec, optional selective analysis flags, and optional SHAP explainability.
 
 **Parameters:**
 - `ticker` (string, path, required): Stock ticker symbol
 - `test_days` (integer, query, optional, default: 60): Number of days to backtest
 - `retrain_frequency` (integer, query, optional, default: 5): Days between model retraining
+- `fast_mode` (boolean, query, optional): Use faster evaluation settings with explanations disabled by default
+- `include_selective` (boolean, query, optional): Preserve selective-evaluation compatibility
+- `include_selector_variants` (boolean, query, optional): Include selector variant evaluation paths when supported
+- `max_train_rows` (integer, query, optional): Cap the rolling training window for faster runs
+- `include_explanations` (boolean, query, optional): Force SHAP explainability on or off
 
 **Response:** `200 OK`
 ```json
 {
   "ticker": "AAPL",
-  "test_days": 60,
-  "retrain_frequency": 5,
-  "metrics": {
-    "mae": 2.45,
-    "rmse": 3.21,
-    "mape": 1.42,
-    "r2": 0.87,
-    "directional_accuracy": 62.5
+  "featureSpecVersion": "prediction-stack-v2",
+  "test_period": {
+    "start_date": "2024-09-15",
+    "end_date": "2024-12-11",
+    "days": 60
   },
-  "trading_performance": {
+  "models": {
+    "ensemble": {
+      "metrics": {
+        "mae": 2.45,
+        "rmse": 3.21,
+        "mape": 1.42,
+        "r_squared": 0.87,
+        "directional_accuracy": 62.5
+      }
+    },
+    "random_forest": {
+      "metrics": {
+        "mae": 2.61,
+        "rmse": 3.37,
+        "mape": 1.56,
+        "r_squared": 0.84,
+        "directional_accuracy": 60.0
+      },
+      "explainability": {
+        "global_top_features": [
+          {"feature": "lag1", "meanAbsImpact": 1.42}
+        ],
+        "latest_prediction_contributors": [
+          {"feature": "lag1", "value": 175.43, "impact": 0.81}
+        ]
+      }
+    }
+  },
+  "returns": {
     "sharpe_ratio": 1.45,
     "max_drawdown": -8.3,
     "total_return": 12.4,
     "buy_hold_return": 10.2
   },
-  "predictions": [
-    {
-      "date": "2024-09-15",
-      "actual": 175.43,
-      "predicted": 176.12,
-      "error": 0.69
-    }
-  ]
+  "best_model": "ensemble"
 }
 ```
 

--- a/docs/backend/DATA_SPECS.md
+++ b/docs/backend/DATA_SPECS.md
@@ -1,4 +1,4 @@
-# ML Model Evaluation - Data Specifications
+# Prediction Stack v2 - Data Specifications
 
 ## 📊 Overview
 This document defines the exact data requirements for professional backtesting and evaluation of our ML prediction models.
@@ -45,64 +45,63 @@ This document defines the exact data requirements for professional backtesting a
 
 ---
 
-## 2. Feature Engineering (42 Fixed Features)
+## 2. Feature Engineering (Versioned Feature Spec)
 
-### Critical Rule: ALWAYS 42 Features
-Every data window must have exactly 42 features, regardless of data length.
+### Feature Spec Version
+`prediction-stack-v2`
 
-### Feature Breakdown
+The upgraded stack no longer relies on an "always 42 features" rule. Instead it uses a versioned forecasting feature specification orchestrated through `MLForecast`, with the exact realized feature columns depending on the active lag/rolling transforms.
 
-#### A. Lagged Prices (30 features)
+### Feature Families
+
+#### A. Lag Features
 ```python
-lag_1  = Close price 1 day ago
-lag_2  = Close price 2 days ago
-...
-lag_30 = Close price 30 days ago
+lag_1
+lag_2
+lag_3
+lag_5
+lag_10
+lag_20
 ```
-**Purpose:** Capture historical price patterns
+**Purpose:** Capture short and medium-term price memory.
 
-#### B. Moving Averages (4 features)
+#### B. Rolling Trend Features
 ```python
-MA_5  = 5-day simple moving average
-MA_10 = 10-day simple moving average
-MA_20 = 20-day simple moving average
-MA_30 = 30-day simple moving average
+rolling_mean_lag1_window_size3
+rolling_mean_lag1_window_size5
+rolling_mean_lag1_window_size10
+rolling_mean_lag5_window_size3
 ```
-**Purpose:** Identify trends and support/resistance levels
+**Purpose:** Capture local trend and smoothing behavior without hand-maintaining a fixed feature count.
 
-#### C. Volatility (3 features)
+#### C. Rolling Volatility Features
 ```python
-std_5  = 5-day price standard deviation
-std_10 = 10-day price standard deviation
-std_20 = 20-day price standard deviation
+rolling_std_lag1_window_size3
+rolling_std_lag1_window_size5
+rolling_std_lag1_window_size10
 ```
-**Purpose:** Measure price stability and risk
+**Purpose:** Capture changing risk and dispersion regimes.
 
-#### D. Price Momentum (3 features)
+#### D. Momentum / Return Features
+Momentum is represented implicitly through lag structure and rolling transforms rather than a hard-coded return-only block.
+
+#### E. Volume-Derived Features
 ```python
-return_1day  = (Close today - Close 1 day ago) / Close 1 day ago
-return_5day  = (Close today - Close 5 days ago) / Close 5 days ago
-return_20day = (Close today - Close 20 days ago) / Close 20 days ago
+volume_ratio_5
+volume_ratio_20
 ```
-**Purpose:** Capture short, medium, and long-term momentum
+**Purpose:** Detect unusual trading activity relative to recent participation.
 
-#### E. Volume Features (2 features)
+#### F. Session / Calendar Features
 ```python
-volume_ratio_5  = Today's volume / 5-day average volume
-volume_ratio_20 = Today's volume / 20-day average volume
+session_weekday
+session_month
+session_quarter
 ```
-**Purpose:** Detect unusual trading activity
+**Purpose:** Provide limited calendar structure while forecast horizons are mapped back to actual trading sessions.
 
-### Total Features: 42
-
-### Handling Early Data (Day 1-30)
-```python
-# If not enough history, use forward-fill strategy:
-- For lags: Use earliest available price
-- For MAs: Use available data (partial MA)
-- For returns: Use 0 if no history
-- For volume: Use 1.0 as neutral ratio
-```
+### Handling Early Data
+The feature pipeline uses partial rolling windows where appropriate and fills neutral defaults for unavailable volume ratios. Training still requires sufficient overall history before a model is considered eligible.
 
 ---
 
@@ -134,11 +133,10 @@ Iteration 12: Train on [1-305],  predict day 310
 
 ### Parameters
 ```python
-LOOKBACK_DAYS = 30        # For feature engineering
-MIN_TRAIN_DAYS = 250      # Minimum training data
+MIN_TRAIN_DAYS = 120      # Minimum history for production ensemble eligibility
 TEST_DAYS = 60            # Testing period
-RETRAIN_FREQUENCY = 5     # Retrain every 5 days
-PREDICTION_HORIZON = 1    # Predict 1 day ahead
+RETRAIN_FREQUENCY = 5     # Retrain every 5 trading sessions
+PREDICTION_HORIZON = 1    # Predict 1 trading session ahead in rolling evaluation
 STEP_SIZE = 1             # Evaluate every day
 ```
 
@@ -146,38 +144,56 @@ STEP_SIZE = 1             # Evaluate every day
 
 ## 4. Model Training Requirements
 
-### Random Forest
+### Statistical Benchmarks (`StatsForecast`)
+```python
+naive
+seasonal_naive_5
+auto_arima
+```
+
+### Production ML Models (`MLForecast`)
+
+#### Random Forest
 ```python
 {
-    'n_estimators': 100,
-    'max_depth': 10,
-    'min_samples_split': 5,
+    'n_estimators': 200,
+    'max_depth': 12,
+    'min_samples_split': 4,
     'min_samples_leaf': 2,
     'random_state': 42,
     'n_jobs': -1
 }
 ```
 
-### XGBoost
+#### XGBoost
 ```python
 {
-    'n_estimators': 100,
-    'max_depth': 5,
-    'learning_rate': 0.1,
-    'subsample': 0.8,
-    'colsample_bytree': 0.8,
+    'n_estimators': 200,
+    'max_depth': 6,
+    'learning_rate': 0.05,
+    'subsample': 0.85,
+    'colsample_bytree': 0.85,
     'random_state': 42,
-    'n_jobs': -1
+    'n_jobs': 1
 }
 ```
 
-### Linear Regression (AutoReg)
+#### Linear Regression
 ```python
 {
-    'lags': 5,
-    'trend': 'n'
+    'model': 'sklearn.linear_model.LinearRegression',
+    'orchestrator': 'MLForecast'
 }
 ```
+
+### Production Ensemble
+The live production ensemble is a weighted average of:
+- `auto_arima`
+- `linear_regression`
+- `random_forest`
+- `xgboost`
+
+Weights are derived from recent rolling validation error using inverse-error normalization, with equal-weight fallback when validation is unavailable.
 
 ---
 
@@ -216,28 +232,20 @@ False Negatives      = Predicted down, went up
 
 ### Input DataFrame
 ```python
-Shape: (504, 43)  # 504 days × (42 features + 1 target)
+Shape: (N, feature_count + 1 target)
 
 Index: DatetimeIndex(['2023-11-01', '2023-11-02', ...])
 
 Columns:
-- Close          # TARGET
-- lag_1          # Feature 1
-- lag_2          # Feature 2
-...
-- lag_30         # Feature 30
-- MA_5           # Feature 31
-- MA_10          # Feature 32
-- MA_20          # Feature 33
-- MA_30          # Feature 34
-- std_5          # Feature 35
-- std_10         # Feature 36
-- std_20         # Feature 37
-- return_1day    # Feature 38
-- return_5day    # Feature 39
-- return_20day   # Feature 40
-- volume_ratio_5 # Feature 41
-- volume_ratio_20# Feature 42
+- y                            # TARGET
+- lag_1, lag_2, lag_3, ...
+- rolling_mean_lag1_window_size3, ...
+- rolling_std_lag1_window_size3, ...
+- volume_ratio_5
+- volume_ratio_20
+- session_weekday
+- session_month
+- session_quarter
 ```
 
 ### Output JSON
@@ -299,13 +307,14 @@ Columns:
 ### Phase 1: Data Preparation
 - [ ] Download 2 years of historical data via yfinance
 - [ ] Validate data quality (no missing values)
-- [ ] Create 42 fixed features
+- [ ] Create versioned forecasting features through MLForecast
 - [ ] Handle early data (first 30 days)
 - [ ] Normalize/standardize features
 - [ ] Split into train/test windows
 
 ### Phase 2: Model Training
 - [ ] Implement rolling window logic
+- [ ] Train statistical benchmark models on first window
 - [ ] Train Random Forest on first window
 - [ ] Train XGBoost on first window
 - [ ] Train Linear Regression on first window
@@ -321,6 +330,7 @@ Columns:
 ### Phase 4: API Integration
 - [ ] Create `/evaluate/<ticker>` endpoint
 - [ ] Return comprehensive JSON response
+- [ ] Include optional SHAP explainability payloads
 - [ ] Add error handling
 - [ ] Add logging
 
@@ -336,17 +346,20 @@ Columns:
 
 ### Python Code
 ```python
-from professional_evaluation import evaluate_ticker
+from professional_evaluation import rolling_window_backtest
 
 # Evaluate AAPL over 60 days
-result = evaluate_ticker(
+result = rolling_window_backtest(
     ticker='AAPL',
     test_days=60,
-    retrain_frequency=5
+    retrain_frequency=5,
+    fast_mode=False,
+    include_explanations=True,
 )
 
-print(f"MAE: ${result['metrics']['mae']}")
-print(f"MAPE: {result['metrics']['mape']}%")
+print(f"Feature spec: {result['featureSpecVersion']}")
+print(f"MAE: ${result['models']['ensemble']['metrics']['mae']}")
+print(f"MAPE: {result['models']['ensemble']['metrics']['mape']}%")
 print(f"Return: {result['returns']['total_return']}%")
 ```
 

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -168,7 +168,7 @@ function MarqueeTicker() {
 const FEATURES = [
     {
         icon: Brain, title: 'AI-Powered Predictions',
-        desc: 'Ensemble ML model combining Random Forest, XGBoost, and Linear Regression for 7-day price forecasts with model-level breakdown.',
+        desc: 'Unified forecasting stack combining AutoARIMA, Random Forest, XGBoost, and Linear Regression for 7 trading-session forecasts with model-level breakdown.',
         accent: 'from-blue-500 to-indigo-600', glow: 'hover:shadow-blue-500/15',
     },
     {
@@ -199,7 +199,7 @@ const FEATURES = [
 ];
 
 const STATS = [
-    { value: '3',    label: 'ML Models',     sub: 'Random Forest · XGBoost · Linear' },
+    { value: '4',    label: 'Prod. Models',  sub: 'AutoARIMA · RF · XGBoost · Linear' },
     { value: '40+',  label: 'Perf. Metrics', sub: 'Sharpe · Sortino · Max Drawdown' },
     { value: '6',    label: 'Asset Classes', sub: 'Stocks · Forex · Crypto · More' },
     { value: '$100k',label: 'Paper Capital', sub: 'Risk-free trading sandbox' },
@@ -229,8 +229,10 @@ const STEPS = [
         icon: Brain,
         title: 'Analyze the AI Forecast',
         terminal: [
-            { text: 'marketmind predict AAPL --days 7', prefix: '$', color: 'text-gray-300' },
-            { text: 'loading ensemble models...', color: 'text-gray-500', dim: true, think: 150 },
+            { text: 'marketmind predict AAPL --sessions 7', prefix: '$', color: 'text-gray-300' },
+            { text: 'loading forecasting stack...', color: 'text-gray-500', dim: true, think: 150 },
+            { text: '▶ AutoARIMA ...............', color: 'text-purple-400', think: 180 },
+            { text: '  accuracy: 84.6% ✓', color: 'text-gray-400' },
             { text: '▶ Random Forest ...........', color: 'text-purple-400', think: 300 },
             { text: '  accuracy: 87.3% ✓', color: 'text-gray-400' },
             { text: '▶ XGBoost .................', color: 'text-purple-400', think: 250 },
@@ -238,13 +240,13 @@ const STEPS = [
             { text: '▶ Linear Regression .......', color: 'text-purple-400', think: 200 },
             { text: '  accuracy: 82.7% ✓', color: 'text-gray-400' },
             { text: '', color: 'text-gray-400' },
-            { text: '╔═ 7-DAY FORECAST ═════════╗', color: 'text-emerald-500' },
+            { text: '╔═ 7-SESSION FORECAST ═════╗', color: 'text-emerald-500' },
             { text: '║  Direction: BULLISH ▲    ║', color: 'text-emerald-400' },
             { text: '║  Confidence: 84.2%       ║', color: 'text-emerald-400' },
             { text: '║  Target: $190.12 (+4.2%) ║', color: 'text-emerald-400' },
             { text: '╚══════════════════════════╝', color: 'text-emerald-500' },
         ],
-        body: 'See a 7-day directional prediction with per-model breakdown, confidence intervals, and full backtesting results.'
+        body: 'See a 7 trading-session directional prediction with per-model breakdown, confidence scoring, and full backtesting results.'
     },
     {
         num: '3',

--- a/frontend/src/components/ModelPerformancePage.js
+++ b/frontend/src/components/ModelPerformancePage.js
@@ -2,6 +2,22 @@ import React, { useState } from 'react';
 import ActualVsPredictedChart from './charts/ActualVsPredictedChart';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
+const MODEL_LABELS = {
+    ensemble: 'Ensemble',
+    auto_arima: 'AutoARIMA',
+    naive: 'Naive',
+    seasonal_naive_5: 'Seasonal Naive (5)',
+    linear_regression: 'Linear Regression',
+    random_forest: 'Random Forest',
+    xgboost: 'XGBoost',
+    lstm: 'LSTM',
+    transformer: 'Transformer',
+};
+
+const formatModelName = (modelName) => (
+    MODEL_LABELS[modelName] || modelName.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+);
+
 const metricToneClass = (value, positiveIsGood = true) => {
     if (value === null || value === undefined || Number.isNaN(Number(value))) {
         return 'text-mm-text-secondary';
@@ -41,6 +57,7 @@ const ModelPerformancePage = () => {
                     fast_mode: false,
                     include_selective: true,
                     retrain_frequency: 5,
+                    include_explanations: true,
                 }
                 : {
                     test_days: testDays,
@@ -48,6 +65,7 @@ const ModelPerformancePage = () => {
                     include_selective: false,
                     retrain_frequency: 10,
                     max_train_rows: 450,
+                    include_explanations: false,
                 };
 
             const data = await apiRequest(API_ENDPOINTS.EVALUATE(ticker.toUpperCase(), params));
@@ -59,6 +77,9 @@ const ModelPerformancePage = () => {
             setLoading(false);
         }
     };
+
+    const selectedExplainability = evaluationData?.models?.[selectedModel]?.explainability;
+    const selectedModelSupportsShap = ['linear_regression', 'random_forest', 'xgboost'].includes(selectedModel);
 
     return (
         <div className="ui-page animate-fade-in space-y-8">
@@ -146,7 +167,7 @@ const ModelPerformancePage = () => {
             {evaluationData && !loading && (
                 <div className="space-y-8 animate-fade-in">
                     <div className="ui-panel-elevated p-6">
-                        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
                             <div className="text-center">
                                 <p className="text-sm text-mm-text-secondary mb-1">Ticker</p>
                                 <p className="text-2xl font-semibold text-mm-text-primary">{evaluationData.ticker}</p>
@@ -161,13 +182,19 @@ const ModelPerformancePage = () => {
                             <div className="text-center">
                                 <p className="text-sm text-mm-text-secondary mb-1">Best Model</p>
                                 <p className="text-lg font-semibold text-mm-positive">
-                                    {evaluationData.best_model.replace('_', ' ').toUpperCase()}
+                                    {formatModelName(evaluationData.best_model)}
                                 </p>
                             </div>
                             <div className="text-center">
                                 <p className="text-sm text-mm-text-secondary mb-1">Models Tested</p>
                                 <p className="text-lg font-semibold text-mm-accent-primary">
                                     {Object.keys(evaluationData.models).length}
+                                </p>
+                            </div>
+                            <div className="text-center">
+                                <p className="text-sm text-mm-text-secondary mb-1">Feature Spec</p>
+                                <p className="text-lg font-semibold text-mm-text-primary">
+                                    {evaluationData.featureSpecVersion || 'legacy'}
                                 </p>
                             </div>
                         </div>
@@ -182,7 +209,7 @@ const ModelPerformancePage = () => {
                                     onClick={() => setSelectedModel(modelName)}
                                     className={selectedModel === modelName ? 'ui-button-primary px-5 py-3' : 'ui-button-secondary px-5 py-3'}
                                 >
-                                    {modelName.replace('_', ' ').toUpperCase()}
+                                    {formatModelName(modelName)}
                                     {modelName === evaluationData.best_model && <span className="ml-2">🏆</span>}
                                 </button>
                             ))}
@@ -217,7 +244,7 @@ const ModelPerformancePage = () => {
                                                 className={isBest ? 'border-b border-mm-border bg-mm-surface-subtle' : 'border-b border-mm-border'}
                                             >
                                                 <td className="px-4 py-3 font-semibold text-mm-text-primary">
-                                                    {modelName.replace('_', ' ').toUpperCase()}
+                                                    {formatModelName(modelName)}
                                                     {isBest && <span className="ml-2">🏆</span>}
                                                 </td>
                                                 <td className="px-4 py-3 text-center text-mm-text-secondary">${data.metrics.mae}</td>
@@ -275,12 +302,63 @@ const ModelPerformancePage = () => {
                         </div>
                     )}
 
+                    <div className="ui-panel p-6">
+                        <h3 className="mb-2 text-xl font-semibold text-mm-text-primary">Explainability</h3>
+                        <p className="mb-6 text-sm text-mm-text-secondary">
+                            SHAP is available for Linear Regression, Random Forest, and XGBoost in deep evaluation mode.
+                        </p>
+
+                        {selectedExplainability ? (
+                            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                                <div className="ui-panel-subtle p-4">
+                                    <h4 className="mb-3 font-semibold text-mm-text-primary">Global Top Features</h4>
+                                    <div className="space-y-3">
+                                        {(selectedExplainability.global_top_features || []).map((item) => (
+                                            <div key={item.feature} className="flex items-center justify-between gap-4">
+                                                <div>
+                                                    <p className="font-medium text-mm-text-primary">{item.feature}</p>
+                                                    <p className="text-xs text-mm-text-tertiary">Average absolute impact</p>
+                                                </div>
+                                                <p className="font-semibold text-mm-accent-primary">{item.meanAbsImpact}</p>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div className="ui-panel-subtle p-4">
+                                    <h4 className="mb-3 font-semibold text-mm-text-primary">Latest Prediction Contributors</h4>
+                                    <div className="space-y-3">
+                                        {(selectedExplainability.latest_prediction_contributors || []).map((item) => (
+                                            <div key={item.feature} className="grid grid-cols-[1fr_auto_auto] items-center gap-3">
+                                                <div>
+                                                    <p className="font-medium text-mm-text-primary">{item.feature}</p>
+                                                    <p className="text-xs text-mm-text-tertiary">Value: {item.value ?? 'n/a'}</p>
+                                                </div>
+                                                <span className="text-xs text-mm-text-tertiary">Impact</span>
+                                                <p className={metricToneClass(item.impact)}>
+                                                    {item.impact > 0 ? '+' : ''}
+                                                    {item.impact}
+                                                </p>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="ui-panel-subtle p-4 text-sm text-mm-text-secondary">
+                                {selectedModelSupportsShap
+                                    ? 'Run deep evaluation to generate SHAP explainability for this model.'
+                                    : 'SHAP explanations are unavailable for this model. Use Linear Regression, Random Forest, or XGBoost in deep mode.'}
+                            </div>
+                        )}
+                    </div>
+
                     <div className="ui-banner ui-banner-warning">
                         <h3 className="mb-2 font-semibold">About This Evaluation</h3>
                         <ul className="space-y-1 text-sm">
                             <li>• Rolling window backtesting with model retraining every 5 days</li>
-                            <li>• 42 engineered features including lagged prices, moving averages, volatility, momentum, and volume</li>
-                            <li>• Models: Random Forest, XGBoost, Linear Regression, and Ensemble</li>
+                            <li>• Versioned forecasting feature spec with lag, rolling trend, volatility, momentum, volume, and session features</li>
+                            <li>• Ensemble now blends AutoARIMA, Linear Regression, Random Forest, and XGBoost</li>
                             <li>• Metrics: MAE, MAPE, R², and directional accuracy</li>
                             <li>• Past performance does not guarantee future results</li>
                         </ul>

--- a/frontend/src/components/ModelPerformancePage.test.js
+++ b/frontend/src/components/ModelPerformancePage.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ModelPerformancePage from './ModelPerformancePage';
+import { API_ENDPOINTS, apiRequest } from '../config/api';
+
+jest.mock('./charts/ActualVsPredictedChart', () => () => <div data-testid="actual-vs-predicted-chart" />);
+
+jest.mock('../config/api', () => ({
+    API_ENDPOINTS: {
+        EVALUATE: jest.fn((ticker, params) => `/evaluate/${ticker}?${new URLSearchParams(params).toString()}`),
+    },
+    apiRequest: jest.fn(),
+}));
+
+const evaluationPayload = {
+    ticker: 'AAPL',
+    featureSpecVersion: 'prediction-stack-v2',
+    test_period: {
+        start_date: '2026-01-02',
+        end_date: '2026-03-27',
+        days: 60,
+    },
+    dates: ['2026-01-02', '2026-01-05'],
+    actuals: [100.0, 101.0],
+    models: {
+        ensemble: {
+            predictions: [100.4, 101.2],
+            metrics: { mae: 1.1, rmse: 1.3, mape: 1.2, r_squared: 0.81, directional_accuracy: 50.0 },
+        },
+        linear_regression: {
+            predictions: [100.3, 101.4],
+            metrics: { mae: 1.0, rmse: 1.2, mape: 1.1, r_squared: 0.84, directional_accuracy: 50.0 },
+            explainability: {
+                global_top_features: [{ feature: 'lag1', meanAbsImpact: 1.42 }],
+                latest_prediction_contributors: [{ feature: 'lag1', value: 100.0, impact: 0.71 }],
+            },
+        },
+        auto_arima: {
+            predictions: [100.5, 101.0],
+            metrics: { mae: 1.3, rmse: 1.5, mape: 1.4, r_squared: 0.78, directional_accuracy: 50.0 },
+        },
+    },
+    evaluationOptions: { includeExplanations: true },
+    returns: {
+        initial_capital: 10000,
+        final_value: 10125,
+        total_return: 1.25,
+        buy_hold_return: 0.9,
+        outperformance: 0.35,
+        sharpe_ratio: 1.1,
+        max_drawdown: -1.5,
+        num_trades: 2,
+    },
+    best_model: 'linear_regression',
+};
+
+describe('ModelPerformancePage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        API_ENDPOINTS.EVALUATE.mockImplementation((ticker, params) => `/evaluate/${ticker}?${new URLSearchParams(params).toString()}`);
+        apiRequest.mockResolvedValue(evaluationPayload);
+    });
+
+    test('requests deep evaluation with explainability enabled', async () => {
+        render(<ModelPerformancePage />);
+
+        fireEvent.change(screen.getByPlaceholderText(/enter stock ticker/i), {
+            target: { value: 'AAPL' },
+        });
+        fireEvent.click(screen.getByRole('checkbox'));
+        fireEvent.click(screen.getByRole('button', { name: 'Evaluate' }));
+
+        await waitFor(() => {
+            expect(API_ENDPOINTS.EVALUATE).toHaveBeenCalledWith(
+                'AAPL',
+                expect.objectContaining({
+                    fast_mode: false,
+                    include_explanations: true,
+                    include_selective: true,
+                })
+            );
+        });
+        expect(apiRequest).toHaveBeenCalled();
+        expect(await screen.findByText('Feature Spec')).toBeInTheDocument();
+        expect(screen.getByText('prediction-stack-v2')).toBeInTheDocument();
+    });
+
+    test('renders explainability for supported models and fallback for unsupported ones', async () => {
+        render(<ModelPerformancePage />);
+
+        fireEvent.change(screen.getByPlaceholderText(/enter stock ticker/i), {
+            target: { value: 'AAPL' },
+        });
+        fireEvent.click(screen.getByRole('checkbox'));
+        fireEvent.click(screen.getByRole('button', { name: 'Evaluate' }));
+
+        await screen.findByText('Model Comparison');
+
+        fireEvent.click(screen.getByRole('button', { name: /Linear Regression/i }));
+        expect(screen.getByText('Explainability')).toBeInTheDocument();
+        expect(screen.getByText('Global Top Features')).toBeInTheDocument();
+        expect(screen.getAllByText('lag1').length).toBeGreaterThan(0);
+
+        fireEvent.click(screen.getByRole('button', { name: /AutoARIMA/i }));
+        expect(screen.getByText(/SHAP explanations are unavailable for this model/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/PredictionsPage.js
+++ b/frontend/src/components/PredictionsPage.js
@@ -84,7 +84,7 @@ const PredictionsPage = ({ initialTicker }) => {
             <div className="ui-page-header text-center">
                 <h1 className="ui-page-title mb-2">Stock Price Predictions</h1>
                 <p className="ui-page-subtitle">
-                    Get 7-day price predictions powered by machine learning
+                    Get 7 trading-session price predictions powered by a unified forecasting stack
                 </p>
             </div>
 
@@ -239,7 +239,7 @@ const PredictionsPage = ({ initialTicker }) => {
                         Enter a stock ticker to see predictions
                     </h3>
                     <p className="text-mm-text-secondary">
-                        Get AI-powered 7-day price forecasts for any stock
+                        Get 7 trading-session price forecasts for any U.S. stock
                     </p>
                 </div>
             )}

--- a/frontend/src/components/PredictionsPage.test.js
+++ b/frontend/src/components/PredictionsPage.test.js
@@ -31,6 +31,8 @@ describe('PredictionsPage', () => {
     test('uses the ensemble endpoint by default', async () => {
         render(<PredictionsPage />);
 
+        expect(screen.getByText(/7 trading-session price predictions/i)).toBeInTheDocument();
+
         fireEvent.change(screen.getByPlaceholderText(/enter stock ticker/i), {
             target: { value: 'AAPL' },
         });

--- a/frontend/src/components/ui/ModelComparisonCard.js
+++ b/frontend/src/components/ui/ModelComparisonCard.js
@@ -6,6 +6,9 @@ const ModelComparisonCard = ({ modelBreakdown, modelsUsed, confidence }) => {
     const modelLabels = {
         'linear_regression': 'Linear Regression',
         'random_forest': 'Random Forest',
+        'auto_arima': 'AutoARIMA',
+        'naive': 'Naive',
+        'seasonal_naive_5': 'Seasonal Naive (5)',
         'xgboost': 'XGBoost',
         'lstm': 'LSTM',
         'transformer': 'Transformer'
@@ -30,7 +33,7 @@ const ModelComparisonCard = ({ modelBreakdown, modelsUsed, confidence }) => {
                         Model Comparison
                     </h3>
                     <p className="text-sm text-mm-text-secondary mt-1">
-                        Ensemble of {modelsUsed.length} ML models
+                        Ensemble of {modelsUsed.length} statistical and ML models
                     </p>
                 </div>
                 <div className="text-right">
@@ -48,10 +51,10 @@ const ModelComparisonCard = ({ modelBreakdown, modelsUsed, confidence }) => {
                             <div className="flex items-center">
                                 <div>
                                     <h4 className="text-sm font-semibold text-mm-text-primary">
-                                        {modelLabels[model]}
+                                        {modelLabels[model] || model.replace(/_/g, ' ')}
                                     </h4>
                                     <p className="text-xs text-mm-text-tertiary">
-                                        {modelBreakdown[model].length} day forecast
+                                        {modelBreakdown[model].length} trading-session forecast
                                     </p>
                                 </div>
                             </div>
@@ -73,7 +76,7 @@ const ModelComparisonCard = ({ modelBreakdown, modelsUsed, confidence }) => {
                                 </p>
                             </div>
                             <div className="text-center">
-                                <p className="text-mm-text-tertiary">Day 6</p>
+                                <p className="text-mm-text-tertiary">Day {modelBreakdown[model].length}</p>
                                 <p className="font-medium text-mm-text-primary">
                                     ${modelBreakdown[model][modelBreakdown[model].length - 1]}
                                 </p>
@@ -89,7 +92,7 @@ const ModelComparisonCard = ({ modelBreakdown, modelsUsed, confidence }) => {
                         <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                     </svg>
                     <span>
-                        Ensemble combines predictions from multiple models for higher accuracy
+                        Ensemble combines benchmark and ML models using recent validation performance
                     </span>
                 </div>
             </div>

--- a/frontend/src/components/ui/ModelComparisonCard.test.js
+++ b/frontend/src/components/ui/ModelComparisonCard.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ModelComparisonCard from './ModelComparisonCard';
+
+describe('ModelComparisonCard', () => {
+    test('renders statistical and ML model labels', () => {
+        render(
+            <ModelComparisonCard
+                modelBreakdown={{
+                    auto_arima: [101.1, 101.4, 101.8, 102.0, 102.2, 102.5, 102.8],
+                    linear_regression: [101.0, 101.3, 101.7, 101.9, 102.1, 102.4, 102.7],
+                    random_forest: [101.2, 101.5, 101.9, 102.1, 102.3, 102.7, 103.0],
+                }}
+                modelsUsed={['auto_arima', 'linear_regression', 'random_forest']}
+                confidence={88.4}
+            />
+        );
+
+        expect(screen.getByText('AutoARIMA')).toBeInTheDocument();
+        expect(screen.getByText('Linear Regression')).toBeInTheDocument();
+        expect(screen.getByText('Random Forest')).toBeInTheDocument();
+        expect(screen.getByText(/statistical and ML models/i)).toBeInTheDocument();
+        expect(screen.getAllByText('7 trading-session forecast')).toHaveLength(3);
+    });
+});

--- a/frontend/src/components/ui/PredictionPreviewCard.js
+++ b/frontend/src/components/ui/PredictionPreviewCard.js
@@ -60,7 +60,7 @@ const PredictionPreviewCard = ({ predictionData, onViewFullPredictions }) => {
                 onClick={onViewFullPredictions}
                 className="ui-button-primary w-full"
             >
-                <span>See Full 7-Week Forecast</span>
+                <span>See Full 7-Session Forecast</span>
                 <svg className="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>

--- a/frontend/src/components/ui/PredictionPreviewCard.test.js
+++ b/frontend/src/components/ui/PredictionPreviewCard.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import PredictionPreviewCard from './PredictionPreviewCard';
+
+describe('PredictionPreviewCard', () => {
+    test('renders the updated 7-session CTA', () => {
+        const onViewFullPredictions = jest.fn();
+        render(
+            <PredictionPreviewCard
+                predictionData={{
+                    predictions: [
+                        { date: '2026-04-03', predictedClose: 101.5 },
+                        { date: '2026-04-06', predictedClose: 102.2 },
+                        { date: '2026-04-07', predictedClose: 102.9 },
+                    ],
+                }}
+                onViewFullPredictions={onViewFullPredictions}
+            />
+        );
+
+        expect(screen.getByText('Next 3 trading sessions')).toBeInTheDocument();
+        expect(screen.getByText('See Full 7-Session Forecast')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /See Full 7-Session Forecast/i }));
+        expect(onViewFullPredictions).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary
- replace the ad hoc classical prediction stack with a centralized StatsForecast + MLForecast service
- keep prediction and public v1 route contracts stable while switching ensemble forecasting to trading-session-aware dates
- add SHAP explainability to deep evaluation and refresh the predictions/model-performance UI and docs

## Testing
- backend/.venv/bin/python -m unittest -v backend.tests.test_prediction_service backend.tests.test_prediction_stack_routes backend.tests.test_chart_prediction_append
- backend/.venv/bin/python -m unittest -v backend.tests.test_public_api_beta backend.tests.test_marketmind_ai_api backend.tests.test_deliverables_api backend.tests.test_route_registration_smoke
- PYTHON_BIN=/Users/tazeemmahashin/MarketMind/backend/.venv/bin/python bash backend/run_deterministic_backend_checks.sh
- npm test -- --watch=false --runInBand --runTestsByPath src/components/PredictionsPage.test.js src/components/ModelPerformancePage.test.js src/components/ui/PredictionPreviewCard.test.js src/components/ui/ModelComparisonCard.test.js
- bash frontend/run_frontend_checks.sh

## Notes
- shap is pinned to 0.49.1 because this repo currently runs on Python 3.10, and shap 0.51.0 requires Python 3.11+
- LSTM and Transformer routes remain available as legacy explicit-only models and are no longer part of the production ensemble