### PR TITLE
feat(ai): add MarketMind research retrieval v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,18 @@ FINNHUB_API_KEY=your_finnhub_key_here
 # Keep false by default so US-only deployments do not depend on scraper-backed international data.
 AKSHARE_ENABLED=false
 
+# MarketMind research retrieval (optional - enables SentenceTransformers + Qdrant evidence retrieval for MarketMindAI)
+# Keep false by default so MarketMindAI continues using context-only mode unless retrieval is explicitly enabled.
+RESEARCH_RETRIEVAL_ENABLED=false
+# QDRANT_URL=:memory:
+# QDRANT_API_KEY=
+# QDRANT_GLOBAL_COLLECTION=marketmind_global_research_v1
+# QDRANT_USER_COLLECTION=marketmind_user_research_v1
+# RETRIEVAL_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+# RETRIEVAL_RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
+# RETRIEVAL_TOP_K=12
+# RETRIEVAL_RERANK_K=8
+
 # ===========================================
 # Backend Configuration
 # ===========================================

--- a/backend/api.py
+++ b/backend/api.py
@@ -123,6 +123,7 @@ from marketmind_ai import (
     get_marketmind_ai_artifact_detail,
     get_marketmind_ai_artifact_download,
     get_marketmind_ai_chat_detail,
+    get_marketmind_ai_retrieval_status,
     list_marketmind_ai_artifacts,
     list_marketmind_ai_chats,
 )
@@ -1170,6 +1171,27 @@ def get_marketmind_ai_context():
         session_scope=user_state_session_scope,
         database_url=DATABASE_URL,
         build_context_fn=build_marketmind_ai_context,
+        get_current_user_id_fn=get_current_user_id,
+        error_cls=MarketMindAIError,
+        jsonify_fn=jsonify,
+    )
+
+
+@app.route('/marketmind-ai/retrieval-status', methods=['GET'])
+@require_auth
+@limiter.limit(RateLimits.LIGHT)
+def get_marketmind_ai_retrieval_status_route():
+    ticker = request.args.get('ticker', '').strip().upper()
+    market = request.args.get('market', '').strip()
+    return marketmind_ai_handlers.get_retrieval_status_handler(
+        ticker=ticker,
+        market=market,
+        deliverables_ready_fn=_deliverables_ready,
+        not_configured_response_fn=_marketmind_ai_not_configured_response,
+        ensure_storage_ready_fn=_ensure_user_state_storage_ready,
+        session_scope=user_state_session_scope,
+        database_url=DATABASE_URL,
+        get_retrieval_status_fn=get_marketmind_ai_retrieval_status,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
         jsonify_fn=jsonify,

--- a/backend/api_handlers_marketmind_ai.py
+++ b/backend/api_handlers_marketmind_ai.py
@@ -112,6 +112,38 @@ def get_context_handler(
         return jsonify_fn(body), exc.status_code
 
 
+def get_retrieval_status_handler(
+    *,
+    ticker,
+    market,
+    deliverables_ready_fn,
+    not_configured_response_fn,
+    ensure_storage_ready_fn,
+    session_scope,
+    database_url,
+    get_retrieval_status_fn,
+    get_current_user_id_fn,
+    error_cls,
+    jsonify_fn,
+):
+    if not deliverables_ready_fn():
+        return not_configured_response_fn()
+
+    ensure_storage_ready_fn()
+    try:
+        with session_scope(database_url) as session:
+            payload = get_retrieval_status_fn(
+                session,
+                get_current_user_id_fn(),
+                ticker,
+                market=market,
+            )
+        return jsonify_fn(payload)
+    except error_cls as exc:
+        body = {"error": str(exc), **exc.payload}
+        return jsonify_fn(body), exc.status_code
+
+
 def post_chat_handler(
     *,
     payload,

--- a/backend/marketmind_ai.py
+++ b/backend/marketmind_ai.py
@@ -27,6 +27,7 @@ from openrouter_client import (
     create_structured_completion,
 )
 import exchange_session_service
+import research_retrieval_service
 import sec_filings_service
 from user_state_store import (
     Deliverable,
@@ -390,12 +391,15 @@ def _artifact_summary(row: Deliverable, latest_version: Optional[int] = None) ->
 
 
 def _artifact_version_payload(row: DeliverableMemo) -> Dict[str, Any]:
+    context_snapshot = dict(row.context_snapshot_json or {})
     return {
         "id": str(row.id),
         "version": row.version,
         "modelSlug": row.model_slug,
         "generationStatus": row.generation_status,
         "structuredContent": dict(row.structured_content_json or {}),
+        "retrievedEvidence": list(context_snapshot.get("retrievedEvidence") or []),
+        "retrievalStatus": dict(context_snapshot.get("retrievalStatus") or {}),
         "mimeType": row.mime_type,
         "hasArtifact": bool(row.docx_blob),
         "createdAt": _serialize_timestamp(row.created_at),
@@ -507,6 +511,60 @@ def _compact_context_summary(context: Optional[Dict[str, Any]]) -> Optional[Dict
         ),
         "newsCount": len(context.get("recentNews") or []),
     }
+
+
+def _condense_retrieved_evidence(retrieved_evidence: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    condensed: List[Dict[str, Any]] = []
+    for item in retrieved_evidence or []:
+        condensed.append(
+            {
+                "ticker": item.get("ticker"),
+                "docType": item.get("docType"),
+                "title": item.get("title"),
+                "snippet": item.get("snippet"),
+                "source": item.get("source"),
+                "sourceUrl": item.get("sourceUrl"),
+                "assetId": item.get("assetId"),
+                "score": item.get("score"),
+                "rank": item.get("rank"),
+            }
+        )
+    return condensed
+
+
+def _retrieval_evidence_by_ticker(retrieved_evidence: Optional[List[Dict[str, Any]]]) -> Dict[str, List[Dict[str, Any]]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for item in _condense_retrieved_evidence(retrieved_evidence):
+        ticker = str(item.get("ticker") or item.get("assetId") or "UNKNOWN")
+        grouped.setdefault(ticker, []).append(item)
+    return grouped
+
+
+def _retrieval_query_text(latest_user_message: str, context: Optional[Dict[str, Any]]) -> str:
+    parts = [str(latest_user_message or "").strip()]
+    if context:
+        ticker = context.get("ticker")
+        company_name = (context.get("fundamentalsSummary") or {}).get("companyName") or context.get("assetName")
+        if ticker:
+            parts.append(f"Ticker: {ticker}")
+        if company_name:
+            parts.append(f"Company: {company_name}")
+    return "\n".join(part for part in parts if part)
+
+
+def _retrieval_query_text_for_compare(latest_user_message: str, contexts: List[Dict[str, Any]]) -> str:
+    parts = [str(latest_user_message or "").strip()]
+    compare_labels = []
+    for context in contexts:
+        ticker = context.get("ticker")
+        company_name = (context.get("fundamentalsSummary") or {}).get("companyName") or context.get("assetName")
+        if ticker and company_name:
+            compare_labels.append(f"{ticker} ({company_name})")
+        elif ticker:
+            compare_labels.append(str(ticker))
+    if compare_labels:
+        parts.append("Compare pair: " + " vs ".join(compare_labels))
+    return "\n".join(part for part in parts if part)
 
 
 CONTEXT_DENIAL_PATTERNS = (
@@ -704,8 +762,10 @@ def _build_compare_chat_messages(
     compare_pair: List[str],
     compare_contexts: List[Dict[str, Any]],
     mode: Optional[str],
+    retrieved_evidence: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, str]]:
     assembled = [{"role": "system", "content": CHAT_SYSTEM_PROMPT}]
+    evidence_json = json.dumps(_retrieval_evidence_by_ticker(retrieved_evidence), indent=2)
     assembled.append(
         {
             "role": "system",
@@ -716,6 +776,11 @@ def _build_compare_chat_messages(
                 f"Mode: {str(mode or 'general').strip().lower()}\n"
                 f"Compare pair: {compare_pair[0]} vs {compare_pair[1]}\n"
                 f"Contexts JSON:\n{json.dumps(compare_contexts, indent=2)}"
+                + (
+                    f"\nRetrieved evidence grouped by ticker:\n{evidence_json}"
+                    if retrieved_evidence
+                    else ""
+                )
             ),
         }
     )
@@ -902,6 +967,7 @@ def _build_chat_messages(
     context: Optional[Dict[str, Any]],
     mode: Optional[str],
     ticker_resolution: Optional[Dict[str, Optional[str]]] = None,
+    retrieved_evidence: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, str]]:
     assembled = [{"role": "system", "content": CHAT_SYSTEM_PROMPT}]
     mode_label = str(mode or "general").strip().lower()
@@ -918,6 +984,7 @@ def _build_chat_messages(
             }
         )
     elif attached_ticker:
+        evidence_json = json.dumps(_condense_retrieved_evidence(retrieved_evidence), indent=2)
         assembled.append(
             {
                 "role": "system",
@@ -926,6 +993,11 @@ def _build_chat_messages(
                     f"Mode: {mode_label}\n"
                     f"Ticker: {attached_ticker}\n"
                     f"Context JSON:\n{json.dumps(context or {}, indent=2)}"
+                    + (
+                        f"\nRetrieved evidence JSON:\n{evidence_json}"
+                        if retrieved_evidence
+                        else ""
+                    )
                 ),
             }
         )
@@ -949,6 +1021,7 @@ def _build_artifact_prompt_payload(
     artifact_title: str,
     messages: List[Dict[str, str]],
     context: Dict[str, Any],
+    retrieved_evidence: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     transcript = [
         {"role": message["role"], "content": message["content"]}
@@ -966,6 +1039,7 @@ def _build_artifact_prompt_payload(
         ],
         "conversationTranscript": transcript,
         "marketMindContext": context,
+        "retrievedEvidence": _condense_retrieved_evidence(retrieved_evidence),
     }
 
 
@@ -1308,6 +1382,21 @@ def build_marketmind_ai_context(
     return base_context
 
 
+def get_marketmind_ai_retrieval_status(
+    session: Session,
+    clerk_user_id: str,
+    ticker: str,
+    *,
+    market: Optional[str] = None,
+) -> Dict[str, Any]:
+    context = build_marketmind_ai_context(session, clerk_user_id, ticker, market=market)
+    return research_retrieval_service.get_status_for_context(
+        session,
+        clerk_user_id,
+        context=context,
+    )
+
+
 def generate_marketmind_ai_reply(
     session: Session,
     clerk_user_id: str,
@@ -1337,7 +1426,19 @@ def generate_marketmind_ai_reply(
             build_marketmind_ai_context(session, clerk_user_id, compare_pair[0]),
             build_marketmind_ai_context(session, clerk_user_id, compare_pair[1]),
         ]
-        ai_messages = _build_compare_chat_messages(normalized_messages, compare_pair, compare_contexts, mode)
+        retrieval_payload = research_retrieval_service.retrieve_for_compare(
+            session,
+            clerk_user_id,
+            query_text=_retrieval_query_text_for_compare(latest_user_message, compare_contexts),
+            contexts=compare_contexts,
+        )
+        ai_messages = _build_compare_chat_messages(
+            normalized_messages,
+            compare_pair,
+            compare_contexts,
+            mode,
+            retrieved_evidence=retrieval_payload.get("retrievedEvidence"),
+        )
         completion = create_chat_completion(messages=ai_messages, model=DEFAULT_OPENROUTER_MODEL)
         completion = _ensure_grounded_compare_completion(
             ai_messages=ai_messages,
@@ -1363,6 +1464,8 @@ def generate_marketmind_ai_reply(
             "contextSummary": None,
             "comparePair": compare_pair,
             "compareContextSummary": [_compact_context_summary(context) for context in compare_contexts],
+            "retrievedEvidence": retrieval_payload.get("retrievedEvidence") or [],
+            "retrievalStatus": retrieval_payload.get("retrievalStatus") or {},
             "suggestedActions": [],
             "artifactIntent": None,
             "tickerResolution": {
@@ -1375,7 +1478,24 @@ def generate_marketmind_ai_reply(
     ticker_resolution = _resolve_latest_ticker(latest_user_message, previous_ticker)
     ticker = _normalize_ticker(ticker_resolution.get("resolvedTicker"))
     context = build_marketmind_ai_context(session, clerk_user_id, ticker) if ticker else None
-    ai_messages = _build_chat_messages(normalized_messages, ticker, context, mode, ticker_resolution=ticker_resolution)
+    retrieval_payload = (
+        research_retrieval_service.retrieve_for_context(
+            session,
+            clerk_user_id,
+            query_text=_retrieval_query_text(latest_user_message, context),
+            context=context,
+        )
+        if ticker and context
+        else {"retrievedEvidence": [], "retrievalStatus": {}}
+    )
+    ai_messages = _build_chat_messages(
+        normalized_messages,
+        ticker,
+        context,
+        mode,
+        ticker_resolution=ticker_resolution,
+        retrieved_evidence=retrieval_payload.get("retrievedEvidence"),
+    )
     completion = create_chat_completion(messages=ai_messages, model=DEFAULT_OPENROUTER_MODEL)
     completion = _ensure_grounded_completion(
         ai_messages=ai_messages,
@@ -1399,6 +1519,8 @@ def generate_marketmind_ai_reply(
         "assistantMessage": assistant_message,
         "chat": chat_summary,
         "contextSummary": _compact_context_summary(context),
+        "retrievedEvidence": retrieval_payload.get("retrievedEvidence") or [],
+        "retrievalStatus": retrieval_payload.get("retrievalStatus") or {},
         "suggestedActions": [] if artifact_intent and artifact_intent.get("autoGenerate") else _infer_suggested_actions(normalized_messages, ticker),
         "artifactIntent": artifact_intent,
         "tickerResolution": ticker_resolution,
@@ -1531,6 +1653,18 @@ def generate_marketmind_ai_artifact(
         )
 
     context = build_marketmind_ai_context(session, clerk_user_id, attached_ticker)
+    latest_user_message = _meaningful_user_messages(normalized_messages)[-1]["content"] if _meaningful_user_messages(normalized_messages) else attached_ticker
+    retrieval_payload = research_retrieval_service.retrieve_for_context(
+        session,
+        clerk_user_id,
+        query_text=_retrieval_query_text(latest_user_message, context),
+        context=context,
+    )
+    context_with_retrieval = {
+        **context,
+        "retrievedEvidence": retrieval_payload.get("retrievedEvidence") or [],
+        "retrievalStatus": retrieval_payload.get("retrievalStatus") or {},
+    }
     now = utcnow()
     artifact_row: Deliverable
 
@@ -1561,6 +1695,7 @@ def generate_marketmind_ai_artifact(
         artifact_title=artifact_row.title,
         messages=normalized_messages,
         context=context,
+        retrieved_evidence=retrieval_payload.get("retrievedEvidence"),
     )
     prompt_messages = _build_artifact_messages(prompt_payload)
 
@@ -1587,7 +1722,7 @@ def generate_marketmind_ai_artifact(
             model_slug=ai_result["model"],
             generation_status="completed",
             prompt_snapshot_json={"messages": prompt_messages, "sourceMessages": normalized_messages},
-            context_snapshot_json=context,
+            context_snapshot_json=context_with_retrieval,
             structured_content_json=structured_content,
             docx_blob=artifact_bytes,
             mime_type=DOCX_MIME_TYPE,
@@ -1597,6 +1732,15 @@ def generate_marketmind_ai_artifact(
         session.add(version)
         artifact_row.updated_at = utcnow()
         session.flush()
+        try:
+            research_retrieval_service.index_memo_version(
+                clerk_user_id=clerk_user_id,
+                ticker=attached_ticker,
+                context_snapshot=context_with_retrieval,
+                memo_row=version,
+            )
+        except Exception:
+            pass
         chat_summary = None
         if chat_id:
             chat_summary = save_marketmind_ai_chat_state(
@@ -1619,7 +1763,7 @@ def generate_marketmind_ai_artifact(
             model_slug=DEFAULT_OPENROUTER_MODEL,
             generation_status="failed",
             prompt_snapshot_json={"messages": prompt_messages, "sourceMessages": normalized_messages},
-            context_snapshot_json=context,
+            context_snapshot_json=context_with_retrieval,
             structured_content_json={},
             docx_blob=None,
             mime_type=None,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -54,10 +54,12 @@ PyJWT==2.10.1
 psycopg[binary]==3.2.12
 pytz==2025.2
 PyYAML==6.0.1
+qdrant-client==1.17.0
 requests==2.32.5
 redis==5.2.1
 scikit-learn==1.6.1
 scipy==1.13.1
+sentence-transformers==5.2.3
 six==1.17.0
 soupsieve==2.8
 sseclient-py==1.8.0

--- a/backend/research_document_builder.py
+++ b/backend/research_document_builder.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+import akshare_service
+
+
+TARGET_CHUNK_CHARS = 900
+MAX_CHUNK_CHARS = 1200
+CHUNK_OVERLAP_CHARS = 150
+
+
+def _normalize_text(value: Any) -> str:
+    text = str(value or "")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _normalize_snippet(value: Any, *, limit: int = 320) -> str:
+    text = re.sub(r"\s+", " ", _normalize_text(value))
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _chunk_text(text: str) -> List[str]:
+    normalized = _normalize_text(text)
+    if not normalized:
+        return []
+    if len(normalized) <= MAX_CHUNK_CHARS:
+        return [normalized]
+
+    paragraphs = [part.strip() for part in normalized.split("\n\n") if part.strip()]
+    if not paragraphs:
+        paragraphs = [normalized]
+
+    chunks: List[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if current and len(candidate) > TARGET_CHUNK_CHARS:
+            chunks.append(current)
+            overlap = current[-CHUNK_OVERLAP_CHARS:].strip()
+            current = f"{overlap}\n\n{paragraph}".strip() if overlap else paragraph
+        else:
+            current = candidate
+        while len(current) > MAX_CHUNK_CHARS:
+            window = current[:MAX_CHUNK_CHARS]
+            chunks.append(window.rstrip())
+            current = current[MAX_CHUNK_CHARS - CHUNK_OVERLAP_CHARS :].strip()
+    if current:
+        chunks.append(current)
+    return [chunk for chunk in chunks if chunk.strip()]
+
+
+def _point_id(source_type: str, source_id: str, chunk_index: int, version: str) -> str:
+    stable_key = f"{source_type}:{source_id}:{chunk_index}:{version}"
+    return hashlib.sha1(stable_key.encode("utf-8")).hexdigest()
+
+
+def _documents_hash(documents: Iterable[Dict[str, Any]]) -> str:
+    payload = json.dumps(list(documents), sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _base_payload(
+    *,
+    scope: str,
+    clerk_user_id: Optional[str],
+    asset_id: str,
+    ticker: str,
+    market: str,
+    asset_type: str,
+    doc_type: str,
+    source: str,
+    source_id: str,
+    title: Optional[str],
+    section_key: Optional[str],
+    published_at: Optional[str],
+    source_url: Optional[str],
+    language: str,
+    version: str,
+) -> Dict[str, Any]:
+    return {
+        "scope": scope,
+        "clerkUserId": clerk_user_id,
+        "assetId": asset_id,
+        "ticker": ticker,
+        "market": market,
+        "assetType": asset_type,
+        "docType": doc_type,
+        "source": source,
+        "sourceId": source_id,
+        "title": title,
+        "sectionKey": section_key,
+        "publishedAt": published_at,
+        "sourceUrl": source_url,
+        "language": language,
+        "version": version,
+    }
+
+
+def _expand_to_chunks(document: Dict[str, Any]) -> List[Dict[str, Any]]:
+    text = _normalize_text(document.get("text"))
+    if not text:
+        return []
+    chunks = _chunk_text(text)
+    chunk_count = len(chunks)
+    payload_base = dict(document["payload"])
+    payload_base["chunkCount"] = chunk_count
+    expanded = []
+    for index, chunk_text in enumerate(chunks):
+        payload = dict(payload_base)
+        payload["chunkIndex"] = index
+        payload["text"] = chunk_text
+        payload["snippet"] = _normalize_snippet(chunk_text)
+        expanded.append(
+            {
+                "id": _point_id(
+                    payload["docType"],
+                    payload["sourceId"],
+                    index,
+                    payload.get("version") or "v1",
+                ),
+                "text": chunk_text,
+                "payload": payload,
+            }
+        )
+    return expanded
+
+
+def _single_chunk_document(
+    *,
+    scope: str,
+    clerk_user_id: Optional[str],
+    asset_id: str,
+    ticker: str,
+    market: str,
+    asset_type: str,
+    doc_type: str,
+    source: str,
+    source_id: str,
+    title: Optional[str],
+    text: str,
+    section_key: Optional[str] = None,
+    published_at: Optional[str] = None,
+    source_url: Optional[str] = None,
+    language: str = "en",
+    version: str = "v1",
+) -> List[Dict[str, Any]]:
+    payload = _base_payload(
+        scope=scope,
+        clerk_user_id=clerk_user_id,
+        asset_id=asset_id,
+        ticker=ticker,
+        market=market,
+        asset_type=asset_type,
+        doc_type=doc_type,
+        source=source,
+        source_id=source_id,
+        title=title,
+        section_key=section_key,
+        published_at=published_at,
+        source_url=source_url,
+        language=language,
+        version=version,
+    )
+    return _expand_to_chunks({"payload": payload, "text": text})
+
+
+def _build_sec_documents(context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    asset_id = context.get("assetId") or context.get("ticker") or ""
+    ticker = context.get("ticker") or asset_id
+    market = context.get("market") or "US"
+    docs: List[Dict[str, Any]] = []
+
+    filing = context.get("secFilingsSummary") or {}
+    filing_type = filing.get("type")
+    filing_date = filing.get("date")
+    filing_url = filing.get("url")
+    for section in filing.get("sections") or []:
+        section_text = section.get("text")
+        if not section_text:
+            continue
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type="equity",
+                doc_type="sec_section",
+                source="sec",
+                source_id=f"{filing.get('accessionNumber') or filing_type}:{section.get('key')}",
+                title=f"{filing_type or 'SEC filing'} · {section.get('title') or section.get('key')}",
+                text=section_text,
+                section_key=section.get("key"),
+                published_at=filing_date,
+                source_url=filing_url,
+                language="en",
+                version=f"{filing.get('accessionNumber') or filing_date or 'latest'}",
+            )
+        )
+
+    filing_change = context.get("filingChangeSummary") or {}
+    for section_change in filing_change.get("sectionChanges") or []:
+        change_text = "\n".join(
+            part
+            for part in [
+                f"Status: {section_change.get('status')}" if section_change.get("status") else None,
+                section_change.get("currentExcerpt"),
+                section_change.get("previousExcerpt"),
+            ]
+            if part
+        )
+        if not change_text:
+            continue
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type="equity",
+                doc_type="filing_change",
+                source="sec",
+                source_id=f"{filing_change.get('comparisonForm') or 'filing-change'}:{section_change.get('key')}",
+                title=f"{filing_change.get('comparisonForm') or 'Filing change'} · {section_change.get('title') or section_change.get('key')}",
+                text=change_text,
+                section_key=section_change.get("key"),
+                published_at=(filing_change.get("currentFiling") or {}).get("date"),
+                source_url=(filing_change.get("currentFiling") or {}).get("url"),
+                language="en",
+                version=str((filing_change.get("currentFiling") or {}).get("accessionNumber") or "latest"),
+            )
+        )
+
+    for index, item in enumerate(context.get("insiderActivitySummary") or []):
+        insider_name = item.get("insiderName") or "Insider"
+        text = "\n".join(
+            part
+            for part in [
+                f"Activity: {item.get('activity')}" if item.get("activity") else None,
+                f"Form: {item.get('type')}" if item.get("type") else None,
+                f"Date: {item.get('date')}" if item.get("date") else None,
+                f"Shares: {item.get('shares')}" if item.get("shares") is not None else None,
+            ]
+            if part
+        )
+        if not text:
+            continue
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type="equity",
+                doc_type="insider_activity",
+                source="sec",
+                source_id=f"insider:{index}:{insider_name}",
+                title=f"Insider activity · {insider_name}",
+                text=text,
+                published_at=item.get("date"),
+                source_url=item.get("url"),
+                language="en",
+                version="v1",
+            )
+        )
+
+    for index, item in enumerate(context.get("beneficialOwnershipSummary") or []):
+        owners = ", ".join(item.get("owners") or [])
+        text = "\n".join(
+            part
+            for part in [
+                f"Owners: {owners}" if owners else None,
+                f"Disclosure: {item.get('type')}" if item.get("type") else None,
+                f"Ownership percent: {item.get('ownershipPercent')}" if item.get("ownershipPercent") is not None else None,
+                f"Date: {item.get('date')}" if item.get("date") else None,
+            ]
+            if part
+        )
+        if not text:
+            continue
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type="equity",
+                doc_type="beneficial_ownership",
+                source="sec",
+                source_id=f"ownership:{index}:{owners or item.get('type') or 'owner'}",
+                title=f"Beneficial ownership · {owners or item.get('type') or 'holder'}",
+                text=text,
+                published_at=item.get("date"),
+                source_url=item.get("url"),
+                language="en",
+                version="v1",
+            )
+        )
+
+    return docs
+
+
+def _build_news_documents(context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    asset_id = context.get("assetId") or context.get("ticker") or ""
+    ticker = context.get("ticker") or asset_id
+    market = context.get("market") or "US"
+    language = "en" if market == "US" else "zh"
+    docs: List[Dict[str, Any]] = []
+    for index, item in enumerate(context.get("recentNews") or []):
+        title = item.get("title")
+        if not title:
+            continue
+        published_at = item.get("publishedAt") or item.get("publishTime")
+        text = "\n".join(
+            part
+            for part in [
+                title,
+                f"Publisher: {item.get('publisher')}" if item.get("publisher") else None,
+                f"Published: {published_at}" if published_at else None,
+            ]
+            if part
+        )
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type=context.get("assetType") or "equity",
+                doc_type="news",
+                source="news",
+                source_id=f"news:{index}:{title}",
+                title=title,
+                text=text,
+                published_at=published_at,
+                source_url=item.get("link"),
+                language=language,
+                version="v1",
+            )
+        )
+    return docs
+
+
+def _build_company_research_documents(context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    asset_id = context.get("assetId") or context.get("ticker") or ""
+    ticker = context.get("ticker") or asset_id
+    market = context.get("market") or "US"
+    docs: List[Dict[str, Any]] = []
+    company_research = context.get("companyResearchSummary") or {}
+    profile_items = company_research.get("profile") or []
+    if profile_items:
+        profile_text = "\n".join(
+            f"{item.get('label')}: {item.get('value')}"
+            for item in profile_items
+            if item.get("label") and item.get("value")
+        )
+        if profile_text:
+            docs.extend(
+                _single_chunk_document(
+                    scope="global",
+                    clerk_user_id=None,
+                    asset_id=asset_id,
+                    ticker=ticker,
+                    market=market,
+                    asset_type="equity",
+                    doc_type="company_research",
+                    source="akshare",
+                    source_id=f"{asset_id}:profile",
+                    title=f"{context.get('assetName') or ticker} company research",
+                    text=profile_text,
+                    language="zh",
+                    version="v1",
+                )
+            )
+
+    for index, item in enumerate(company_research.get("announcements") or []):
+        title = item.get("title")
+        if not title:
+            continue
+        text = "\n".join(
+            part
+            for part in [
+                title,
+                item.get("summary"),
+                item.get("content"),
+            ]
+            if part
+        )
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type="equity",
+                doc_type="announcement",
+                source="akshare",
+                source_id=f"{asset_id}:announcement:{index}:{title}",
+                title=title,
+                text=text or title,
+                published_at=item.get("publishTime") or item.get("date"),
+                source_url=item.get("link"),
+                language="zh",
+                version="v1",
+            )
+        )
+    return docs
+
+
+def _build_asia_macro_documents(context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    if str(context.get("market") or "").upper() not in {"HK", "CN"}:
+        return []
+    try:
+        payload = akshare_service.get_asia_macro_overview()
+    except Exception:
+        return []
+
+    asset_id = context.get("assetId") or context.get("ticker") or ""
+    ticker = context.get("ticker") or asset_id
+    market = context.get("market") or "HK"
+    docs: List[Dict[str, Any]] = []
+
+    indicator_lines = [
+        f"{item.get('name')}: {item.get('value')}{item.get('unit') or ''} as of {item.get('date') or 'latest'}"
+        for item in (payload.get("indicators") or [])[:6]
+        if item.get("name") and item.get("value") is not None
+    ]
+    signal_lines = [
+        f"{item.get('name')}: {item.get('value')}{item.get('unit') or ''}"
+        for item in (payload.get("marketSignals") or [])[:4]
+        if item.get("name") and item.get("value") is not None
+    ]
+    macro_text = "\n".join(indicator_lines + signal_lines)
+    if macro_text:
+        docs.extend(
+            _single_chunk_document(
+                scope="global",
+                clerk_user_id=None,
+                asset_id=asset_id,
+                ticker=ticker,
+                market=market,
+                asset_type="equity",
+                doc_type="macro_brief",
+                source="akshare_macro",
+                source_id=f"{asset_id}:asia-macro",
+                title="Asia macro backdrop",
+                text=macro_text,
+                language="en",
+                version="v1",
+            )
+        )
+    return docs
+
+
+def build_global_documents(context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    asset_type = context.get("assetType") or "equity"
+    if asset_type != "equity":
+        return []
+    market = str(context.get("market") or "US").upper()
+    docs: List[Dict[str, Any]] = []
+    docs.extend(_build_news_documents(context))
+    if market == "US":
+        docs.extend(_build_sec_documents(context))
+    elif market in {"HK", "CN"}:
+        docs.extend(_build_company_research_documents(context))
+        docs.extend(_build_asia_macro_documents(context))
+    return docs
+
+
+def build_user_memo_documents(
+    *,
+    clerk_user_id: str,
+    ticker: str,
+    asset_id: str,
+    market: str,
+    asset_type: str,
+    memo_rows: Iterable[Any],
+) -> List[Dict[str, Any]]:
+    docs: List[Dict[str, Any]] = []
+    normalized_market = str(market or "US").upper()
+    normalized_ticker = str(ticker or asset_id or "").upper()
+    normalized_asset_id = str(asset_id or normalized_ticker).upper()
+    for row in memo_rows:
+        version = str(getattr(row, "version", "v1"))
+        row_id = str(getattr(row, "id", f"memo-{version}"))
+        structured_content = dict(getattr(row, "structured_content_json", {}) or {})
+        context_snapshot = dict(getattr(row, "context_snapshot_json", {}) or {})
+
+        for section_key, value in structured_content.items():
+            if isinstance(value, list):
+                text = "\n".join(str(item).strip() for item in value if str(item).strip())
+            else:
+                text = str(value or "").strip()
+            if not text:
+                continue
+            docs.extend(
+                _single_chunk_document(
+                    scope="user",
+                    clerk_user_id=clerk_user_id,
+                    asset_id=normalized_asset_id,
+                    ticker=normalized_ticker,
+                    market=normalized_market,
+                    asset_type=asset_type,
+                    doc_type="memo_section",
+                    source="memo",
+                    source_id=f"{row_id}:{section_key}",
+                    title=f"Memo v{version} · {section_key.replace('_', ' ')}",
+                    text=text,
+                    section_key=section_key,
+                    published_at=context_snapshot.get("generatedAt"),
+                    language="en",
+                    version=version,
+                )
+            )
+
+        memo_context_lines = []
+        fundamentals = context_snapshot.get("fundamentalsSummary") or {}
+        if fundamentals.get("companyName"):
+            memo_context_lines.append(f"Company: {fundamentals.get('companyName')}")
+        if fundamentals.get("sector"):
+            memo_context_lines.append(f"Sector: {fundamentals.get('sector')}")
+        prediction = context_snapshot.get("predictionSnapshot") or {}
+        if prediction.get("recentPredicted") is not None:
+            memo_context_lines.append(
+                f"Prediction: {prediction.get('recentPredicted')} vs close {prediction.get('recentClose')}"
+            )
+        for item in context_snapshot.get("retrievedEvidence") or []:
+            if item.get("title"):
+                memo_context_lines.append(
+                    f"Evidence: {item.get('title')} — {item.get('snippet') or ''}".strip()
+                )
+        memo_context_text = "\n".join(line for line in memo_context_lines if line)
+        if memo_context_text:
+            docs.extend(
+                _single_chunk_document(
+                    scope="user",
+                    clerk_user_id=clerk_user_id,
+                    asset_id=normalized_asset_id,
+                    ticker=normalized_ticker,
+                    market=normalized_market,
+                    asset_type=asset_type,
+                    doc_type="memo_context",
+                    source="memo",
+                    source_id=f"{row_id}:context",
+                    title=f"Memo v{version} context snapshot",
+                    text=memo_context_text,
+                    language="en",
+                    version=version,
+                )
+            )
+    return docs
+
+
+def build_documents_digest(documents: Iterable[Dict[str, Any]]) -> str:
+    simplified = [
+        {
+            "id": doc.get("id"),
+            "payload": doc.get("payload"),
+            "text": doc.get("text"),
+        }
+        for doc in documents
+    ]
+    return _documents_hash(simplified)

--- a/backend/research_embedding_service.py
+++ b/backend/research_embedding_service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import importlib
+import os
+from threading import RLock
+from typing import Any, Dict, Iterable, List
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+DEFAULT_RERANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+_RUNTIME_LOCK = RLock()
+_SENTENCE_TRANSFORMERS_MODULE = None
+_DENSE_MODEL = None
+_DENSE_MODEL_NAME = None
+_RERANKER_MODEL = None
+_RERANKER_MODEL_NAME = None
+
+
+class ResearchEmbeddingError(Exception):
+    pass
+
+
+class ResearchEmbeddingUnavailableError(ResearchEmbeddingError):
+    pass
+
+
+def reset_runtime_state() -> None:
+    global _SENTENCE_TRANSFORMERS_MODULE, _DENSE_MODEL, _DENSE_MODEL_NAME, _RERANKER_MODEL, _RERANKER_MODEL_NAME
+    with _RUNTIME_LOCK:
+        _SENTENCE_TRANSFORMERS_MODULE = None
+        _DENSE_MODEL = None
+        _DENSE_MODEL_NAME = None
+        _RERANKER_MODEL = None
+        _RERANKER_MODEL_NAME = None
+
+
+def is_enabled() -> bool:
+    return str(os.getenv("RESEARCH_RETRIEVAL_ENABLED", "")).strip().lower() in TRUE_VALUES
+
+
+def get_embedding_model_name() -> str:
+    return str(os.getenv("RETRIEVAL_EMBEDDING_MODEL") or DEFAULT_EMBEDDING_MODEL).strip()
+
+
+def get_reranker_model_name() -> str:
+    return str(os.getenv("RETRIEVAL_RERANKER_MODEL") or DEFAULT_RERANKER_MODEL).strip()
+
+
+def _load_sentence_transformers_module():
+    global _SENTENCE_TRANSFORMERS_MODULE
+    with _RUNTIME_LOCK:
+        if _SENTENCE_TRANSFORMERS_MODULE is not None:
+            return _SENTENCE_TRANSFORMERS_MODULE
+        try:
+            _SENTENCE_TRANSFORMERS_MODULE = importlib.import_module("sentence_transformers")
+        except ImportError as exc:
+            raise ResearchEmbeddingUnavailableError(
+                "SentenceTransformers is not installed for research retrieval."
+            ) from exc
+        return _SENTENCE_TRANSFORMERS_MODULE
+
+
+def _load_dense_model():
+    global _DENSE_MODEL, _DENSE_MODEL_NAME
+    model_name = get_embedding_model_name()
+    with _RUNTIME_LOCK:
+        if _DENSE_MODEL is not None and _DENSE_MODEL_NAME == model_name:
+            return _DENSE_MODEL
+        module = _load_sentence_transformers_module()
+        try:
+            _DENSE_MODEL = module.SentenceTransformer(model_name)
+        except Exception as exc:
+            raise ResearchEmbeddingUnavailableError(
+                f"Could not load retrieval embedding model {model_name}: {exc}"
+            ) from exc
+        _DENSE_MODEL_NAME = model_name
+        return _DENSE_MODEL
+
+
+def _load_reranker_model():
+    global _RERANKER_MODEL, _RERANKER_MODEL_NAME
+    model_name = get_reranker_model_name()
+    with _RUNTIME_LOCK:
+        if _RERANKER_MODEL is not None and _RERANKER_MODEL_NAME == model_name:
+            return _RERANKER_MODEL
+        module = _load_sentence_transformers_module()
+        try:
+            _RERANKER_MODEL = module.CrossEncoder(model_name)
+        except Exception as exc:
+            raise ResearchEmbeddingUnavailableError(
+                f"Could not load retrieval reranker model {model_name}: {exc}"
+            ) from exc
+        _RERANKER_MODEL_NAME = model_name
+        return _RERANKER_MODEL
+
+
+def get_embedding_dimension() -> int:
+    model = _load_dense_model()
+    dimension_fn = getattr(model, "get_sentence_embedding_dimension", None)
+    if callable(dimension_fn):
+        return int(dimension_fn())
+    sample_vector = encode_documents(["dimension probe"])[0]
+    return len(sample_vector)
+
+
+def _normalize_vectors(vectors: Any) -> List[List[float]]:
+    if hasattr(vectors, "tolist"):
+        vectors = vectors.tolist()
+    if not vectors:
+        return []
+    if isinstance(vectors[0], (int, float)):
+        return [[float(value) for value in vectors]]
+    return [[float(value) for value in vector] for vector in vectors]
+
+
+def encode_documents(texts: Iterable[str]) -> List[List[float]]:
+    normalized_texts = [str(text or "").strip() for text in texts if str(text or "").strip()]
+    if not normalized_texts:
+        return []
+    model = _load_dense_model()
+    encoder = getattr(model, "encode_document", None) or getattr(model, "encode", None)
+    if not callable(encoder):
+        raise ResearchEmbeddingUnavailableError("Dense embedding model does not expose an encode method.")
+    vectors = encoder(normalized_texts, normalize_embeddings=True)
+    return _normalize_vectors(vectors)
+
+
+def encode_query(text: str) -> List[float]:
+    normalized_text = str(text or "").strip()
+    if not normalized_text:
+        raise ResearchEmbeddingUnavailableError("A retrieval query is required.")
+    model = _load_dense_model()
+    encoder = getattr(model, "encode_query", None) or getattr(model, "encode", None)
+    if not callable(encoder):
+        raise ResearchEmbeddingUnavailableError("Dense embedding model does not expose a query encoder.")
+    vector = encoder(normalized_text, normalize_embeddings=True)
+    normalized_vectors = _normalize_vectors(vector)
+    return normalized_vectors[0]
+
+
+def rerank_documents(
+    *,
+    query: str,
+    documents: List[Dict[str, Any]],
+    allow_rerank: bool = True,
+) -> List[Dict[str, Any]]:
+    if not allow_rerank or not documents:
+        return documents
+
+    reranker = _load_reranker_model()
+    pairs = [(str(query or ""), str(doc.get("text") or doc.get("snippet") or "")) for doc in documents]
+    try:
+        scores = reranker.predict(pairs)
+    except Exception as exc:
+        raise ResearchEmbeddingUnavailableError(f"Could not rerank retrieval candidates: {exc}") from exc
+
+    if hasattr(scores, "tolist"):
+        scores = scores.tolist()
+
+    reranked = []
+    for doc, score in zip(documents, scores):
+        next_doc = dict(doc)
+        next_doc["rerankScore"] = float(score)
+        reranked.append(next_doc)
+    reranked.sort(key=lambda item: item.get("rerankScore", float("-inf")), reverse=True)
+    return reranked
+
+
+def get_runtime_status() -> Dict[str, Any]:
+    enabled = is_enabled()
+    status = {
+        "enabled": enabled,
+        "embeddingModel": get_embedding_model_name(),
+        "rerankerModel": get_reranker_model_name(),
+        "available": False,
+    }
+    if not enabled:
+        status["reason"] = "disabled"
+        return status
+    try:
+        model = _load_dense_model()
+        status["available"] = True
+        dimension_fn = getattr(model, "get_sentence_embedding_dimension", None)
+        if callable(dimension_fn):
+            status["embeddingDimension"] = int(dimension_fn())
+        try:
+            _load_reranker_model()
+            status["rerankerAvailable"] = True
+        except ResearchEmbeddingUnavailableError as exc:
+            status["rerankerAvailable"] = False
+            status["rerankerReason"] = str(exc)
+    except ResearchEmbeddingUnavailableError as exc:
+        status["reason"] = str(exc)
+    return status

--- a/backend/research_retrieval_service.py
+++ b/backend/research_retrieval_service.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import os
+from threading import RLock
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import research_document_builder
+import research_embedding_service
+import research_vector_store
+from user_state_store import Deliverable, DeliverableMemo, utcnow
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+_SYNC_LOCK = RLock()
+_GLOBAL_SYNC_STATE: Dict[str, Dict[str, Any]] = {}
+_USER_SYNC_STATE: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+
+class ResearchRetrievalError(Exception):
+    pass
+
+
+def reset_runtime_state() -> None:
+    with _SYNC_LOCK:
+        _GLOBAL_SYNC_STATE.clear()
+        _USER_SYNC_STATE.clear()
+    research_embedding_service.reset_runtime_state()
+    research_vector_store.reset_runtime_state()
+
+
+def is_enabled() -> bool:
+    return str(os.getenv("RESEARCH_RETRIEVAL_ENABLED", "")).strip().lower() in TRUE_VALUES
+
+
+def retrieval_top_k() -> int:
+    try:
+        return max(int(os.getenv("RETRIEVAL_TOP_K", "12")), 1)
+    except ValueError:
+        return 12
+
+
+def retrieval_rerank_k() -> int:
+    try:
+        return max(int(os.getenv("RETRIEVAL_RERANK_K", "8")), 1)
+    except ValueError:
+        return 8
+
+
+def _status(
+    *,
+    enabled: bool,
+    available: bool,
+    used: bool = False,
+    reason: Optional[str] = None,
+    **extra: Any,
+) -> Dict[str, Any]:
+    payload = {
+        "enabled": enabled,
+        "available": available,
+        "used": used,
+    }
+    if reason:
+        payload["reason"] = reason
+    payload.update(extra)
+    return payload
+
+
+def _asset_key(context: Dict[str, Any]) -> str:
+    return str(context.get("assetId") or context.get("ticker") or "").upper()
+
+
+def _ticker_key(context: Dict[str, Any]) -> str:
+    return str(context.get("ticker") or context.get("assetId") or "").upper()
+
+
+def _asset_type(context: Dict[str, Any]) -> str:
+    return str(context.get("assetType") or "equity").lower()
+
+
+def _market(context: Dict[str, Any]) -> str:
+    return str(context.get("market") or "US").upper()
+
+
+def _preferred_doc_types(context: Dict[str, Any]) -> List[str]:
+    market = _market(context)
+    if market == "US":
+        return [
+            "sec_section",
+            "filing_change",
+            "insider_activity",
+            "beneficial_ownership",
+            "news",
+            "memo_section",
+            "memo_context",
+        ]
+    if market in {"HK", "CN"}:
+        return [
+            "announcement",
+            "company_research",
+            "news",
+            "macro_brief",
+            "memo_section",
+            "memo_context",
+        ]
+    return ["news", "memo_section", "memo_context"]
+
+
+def _doc_type_bonus(doc_type: str, preferred_doc_types: List[str]) -> float:
+    if doc_type not in preferred_doc_types:
+        return 0.0
+    rank = preferred_doc_types.index(doc_type)
+    return max(0.0, 0.25 - (rank * 0.03))
+
+
+def _should_rerank(context: Dict[str, Any], candidates: List[Dict[str, Any]]) -> bool:
+    if _market(context) != "US" or not candidates:
+        return False
+    languages = {
+        str((item.get("payload") or {}).get("language") or "").lower()
+        for item in candidates
+        if item.get("payload")
+    }
+    return not languages or all(language.startswith("en") or not language for language in languages)
+
+
+def _prepare_vector_documents(documents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not documents:
+        return []
+    vectors = research_embedding_service.encode_documents(doc["text"] for doc in documents)
+    prepared = []
+    for document, vector in zip(documents, vectors):
+        prepared.append({**document, "vector": vector})
+    return prepared
+
+
+def _sync_global_documents(context: Dict[str, Any]) -> Dict[str, Any]:
+    asset_key = _asset_key(context)
+    documents = research_document_builder.build_global_documents(context)
+    digest = research_document_builder.build_documents_digest(documents)
+    with _SYNC_LOCK:
+        cached = _GLOBAL_SYNC_STATE.get(asset_key)
+        if cached and cached.get("digest") == digest:
+            return dict(cached)
+
+    if not documents:
+        status = {
+            "assetId": asset_key,
+            "docCount": 0,
+            "lastSyncedAt": utcnow().isoformat(),
+            "digest": digest,
+        }
+        with _SYNC_LOCK:
+            _GLOBAL_SYNC_STATE[asset_key] = status
+        return dict(status)
+
+    prepared_documents = _prepare_vector_documents(documents)
+    vector_size = len(prepared_documents[0]["vector"])
+    research_vector_store.upsert_documents("global", prepared_documents, vector_size)
+    doc_count = research_vector_store.count_documents("global", must_filter={"assetId": asset_key})
+    status = {
+        "assetId": asset_key,
+        "docCount": doc_count,
+        "lastSyncedAt": utcnow().isoformat(),
+        "digest": digest,
+    }
+    with _SYNC_LOCK:
+        _GLOBAL_SYNC_STATE[asset_key] = status
+    return dict(status)
+
+
+def _memo_rows_for_context(session: Session, clerk_user_id: str, context: Dict[str, Any]) -> List[DeliverableMemo]:
+    ticker = _ticker_key(context)
+    return (
+        session.scalars(
+            select(DeliverableMemo)
+            .join(Deliverable, Deliverable.id == DeliverableMemo.deliverable_id)
+            .where(
+                Deliverable.clerk_user_id == clerk_user_id,
+                Deliverable.ticker == ticker,
+            )
+            .order_by(DeliverableMemo.created_at.desc(), DeliverableMemo.version.desc())
+            .limit(8)
+        ).all()
+    )
+
+
+def _sync_user_documents(session: Session, clerk_user_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    asset_key = _asset_key(context)
+    ticker = _ticker_key(context)
+    memo_rows = _memo_rows_for_context(session, clerk_user_id, context)
+    documents = research_document_builder.build_user_memo_documents(
+        clerk_user_id=clerk_user_id,
+        ticker=ticker,
+        asset_id=asset_key,
+        market=_market(context),
+        asset_type=_asset_type(context),
+        memo_rows=memo_rows,
+    )
+    digest = research_document_builder.build_documents_digest(documents)
+    cache_key = (clerk_user_id, ticker)
+    with _SYNC_LOCK:
+        cached = _USER_SYNC_STATE.get(cache_key)
+        if cached and cached.get("digest") == digest:
+            return dict(cached)
+
+    if not documents:
+        status = {
+            "assetId": asset_key,
+            "ticker": ticker,
+            "docCount": 0,
+            "lastSyncedAt": utcnow().isoformat(),
+            "digest": digest,
+        }
+        with _SYNC_LOCK:
+            _USER_SYNC_STATE[cache_key] = status
+        return dict(status)
+
+    prepared_documents = _prepare_vector_documents(documents)
+    vector_size = len(prepared_documents[0]["vector"])
+    research_vector_store.upsert_documents("user", prepared_documents, vector_size)
+    doc_count = research_vector_store.count_documents(
+        "user",
+        must_filter={"clerkUserId": clerk_user_id, "assetId": asset_key},
+    )
+    status = {
+        "assetId": asset_key,
+        "ticker": ticker,
+        "docCount": doc_count,
+        "lastSyncedAt": utcnow().isoformat(),
+        "digest": digest,
+    }
+    with _SYNC_LOCK:
+        _USER_SYNC_STATE[cache_key] = status
+    return dict(status)
+
+
+def _normalize_candidates(
+    candidates: Iterable[Dict[str, Any]],
+    *,
+    preferred_doc_types: List[str],
+) -> List[Dict[str, Any]]:
+    normalized: List[Dict[str, Any]] = []
+    for item in candidates:
+        payload = dict(item.get("payload") or {})
+        doc_type = str(payload.get("docType") or "")
+        score = float(item.get("score") or 0.0)
+        normalized.append(
+            {
+                **item,
+                "payload": payload,
+                "text": payload.get("text") or "",
+                "scoreWithBonus": score + _doc_type_bonus(doc_type, preferred_doc_types),
+            }
+        )
+    normalized.sort(key=lambda row: row.get("scoreWithBonus", 0.0), reverse=True)
+    return normalized
+
+
+def _evidence_payload(item: Dict[str, Any], *, rank: int) -> Dict[str, Any]:
+    payload = item.get("payload") or {}
+    return {
+        "docType": payload.get("docType"),
+        "title": payload.get("title"),
+        "snippet": payload.get("snippet") or research_document_builder._normalize_snippet(payload.get("text")),
+        "source": payload.get("source"),
+        "sourceUrl": payload.get("sourceUrl"),
+        "assetId": payload.get("assetId"),
+        "ticker": payload.get("ticker"),
+        "market": payload.get("market"),
+        "score": round(float(item.get("rerankScore", item.get("scoreWithBonus", item.get("score", 0.0)))), 6),
+        "rank": rank,
+        "sectionKey": payload.get("sectionKey"),
+    }
+
+
+def _retrieve_candidates_for_context(
+    session: Session,
+    clerk_user_id: str,
+    query_text: str,
+    context: Dict[str, Any],
+) -> Dict[str, Any]:
+    enabled = is_enabled()
+    if not enabled:
+        return {"evidence": [], "status": _status(enabled=False, available=False, reason="disabled")}
+    if _asset_type(context) != "equity":
+        return {"evidence": [], "status": _status(enabled=True, available=True, reason="unsupported_asset_type")}
+    try:
+        embedding_status = research_embedding_service.get_runtime_status()
+        vector_status = research_vector_store.get_runtime_status()
+        if not embedding_status.get("available"):
+            return {"evidence": [], "status": _status(enabled=True, available=False, reason=embedding_status.get("reason"))}
+        if not vector_status.get("available"):
+            return {"evidence": [], "status": _status(enabled=True, available=False, reason=vector_status.get("reason"))}
+
+        global_sync = _sync_global_documents(context)
+        user_sync = _sync_user_documents(session, clerk_user_id, context)
+        query_vector = research_embedding_service.encode_query(query_text)
+        top_k = retrieval_top_k()
+        preferred_doc_types = _preferred_doc_types(context)
+        global_hits = research_vector_store.query_documents(
+            "global",
+            query_vector=query_vector,
+            limit=top_k,
+            must_filter={"assetId": _asset_key(context)},
+        )
+        user_hits = research_vector_store.query_documents(
+            "user",
+            query_vector=query_vector,
+            limit=top_k,
+            must_filter={"clerkUserId": clerk_user_id, "assetId": _asset_key(context)},
+        )
+        candidates = _normalize_candidates([*global_hits, *user_hits], preferred_doc_types=preferred_doc_types)
+        rerank_used = False
+        if _should_rerank(context, candidates):
+            rerank_limit = min(retrieval_rerank_k(), len(candidates))
+            reranked = research_embedding_service.rerank_documents(
+                query=query_text,
+                documents=candidates[:rerank_limit],
+                allow_rerank=True,
+            )
+            candidates = reranked + candidates[rerank_limit:]
+            candidates.sort(
+                key=lambda item: (
+                    float(item.get("rerankScore", float("-inf"))),
+                    float(item.get("scoreWithBonus", item.get("score", 0.0))),
+                ),
+                reverse=True,
+            )
+            rerank_used = True
+        evidence = [_evidence_payload(item, rank=index + 1) for index, item in enumerate(candidates[:6])]
+        return {
+            "evidence": evidence,
+            "status": _status(
+                enabled=True,
+                available=True,
+                used=bool(evidence),
+                reason=None if evidence else "no_relevant_documents",
+                globalSync=global_sync,
+                userSync=user_sync,
+                candidateCount=len(candidates),
+                rerankUsed=rerank_used,
+            ),
+        }
+    except Exception as exc:
+        return {"evidence": [], "status": _status(enabled=True, available=False, reason=str(exc))}
+
+
+def retrieve_for_context(
+    session: Session,
+    clerk_user_id: str,
+    *,
+    query_text: str,
+    context: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not context or not query_text.strip():
+        return {"retrievedEvidence": [], "retrievalStatus": _status(enabled=is_enabled(), available=is_enabled(), reason="no_context")}
+    result = _retrieve_candidates_for_context(session, clerk_user_id, query_text, context)
+    return {
+        "retrievedEvidence": result["evidence"],
+        "retrievalStatus": result["status"],
+    }
+
+
+def retrieve_for_compare(
+    session: Session,
+    clerk_user_id: str,
+    *,
+    query_text: str,
+    contexts: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not contexts or not query_text.strip():
+        return {"retrievedEvidence": [], "retrievalStatus": _status(enabled=is_enabled(), available=is_enabled(), reason="no_context")}
+    combined_evidence: List[Dict[str, Any]] = []
+    grouped_status: List[Dict[str, Any]] = []
+    for context in contexts:
+        result = _retrieve_candidates_for_context(session, clerk_user_id, query_text, context)
+        ticker = _ticker_key(context)
+        grouped_status.append({"ticker": ticker, **result["status"]})
+        for item in result["evidence"]:
+            combined_evidence.append({**item, "ticker": ticker})
+    combined_evidence.sort(key=lambda item: (item.get("ticker") or "", item.get("rank") or 9999))
+    return {
+        "retrievedEvidence": combined_evidence,
+        "retrievalStatus": _status(
+            enabled=is_enabled(),
+            available=all(status.get("available") for status in grouped_status) if grouped_status else is_enabled(),
+            used=bool(combined_evidence),
+            compare=True,
+            groups=grouped_status,
+        ),
+    }
+
+
+def index_memo_version(
+    *,
+    clerk_user_id: str,
+    ticker: str,
+    context_snapshot: Dict[str, Any],
+    memo_row: DeliverableMemo,
+) -> Dict[str, Any]:
+    if not is_enabled():
+        return _status(enabled=False, available=False, reason="disabled")
+    vector_status = research_vector_store.get_runtime_status()
+    embedding_status = research_embedding_service.get_runtime_status()
+    if not vector_status.get("available"):
+        return _status(enabled=True, available=False, reason=vector_status.get("reason"))
+    if not embedding_status.get("available"):
+        return _status(enabled=True, available=False, reason=embedding_status.get("reason"))
+    documents = research_document_builder.build_user_memo_documents(
+        clerk_user_id=clerk_user_id,
+        ticker=ticker,
+        asset_id=str(context_snapshot.get("assetId") or ticker).upper(),
+        market=str(context_snapshot.get("market") or "US").upper(),
+        asset_type=str(context_snapshot.get("assetType") or "equity").lower(),
+        memo_rows=[memo_row],
+    )
+    if not documents:
+        return _status(enabled=True, available=True, reason="no_documents")
+    prepared_documents = _prepare_vector_documents(documents)
+    vector_size = len(prepared_documents[0]["vector"])
+    upserted = research_vector_store.upsert_documents("user", prepared_documents, vector_size)
+    cache_key = (clerk_user_id, str(ticker or "").upper())
+    with _SYNC_LOCK:
+        _USER_SYNC_STATE.pop(cache_key, None)
+    return _status(enabled=True, available=True, used=bool(upserted), upserted=upserted)
+
+
+def get_status_for_context(
+    session: Session,
+    clerk_user_id: str,
+    *,
+    context: Dict[str, Any],
+) -> Dict[str, Any]:
+    enabled = is_enabled()
+    if not enabled:
+        return _status(enabled=False, available=False, reason="disabled")
+    embedding_status = research_embedding_service.get_runtime_status()
+    vector_status = research_vector_store.get_runtime_status()
+    if not embedding_status.get("available"):
+        return _status(enabled=True, available=False, reason=embedding_status.get("reason"))
+    if not vector_status.get("available"):
+        return _status(enabled=True, available=False, reason=vector_status.get("reason"))
+    global_sync = _sync_global_documents(context)
+    user_sync = _sync_user_documents(session, clerk_user_id, context)
+    return _status(
+        enabled=True,
+        available=True,
+        assetId=_asset_key(context),
+        ticker=_ticker_key(context),
+        globalCollection=research_vector_store.global_collection_name(),
+        userCollection=research_vector_store.user_collection_name(),
+        globalSync=global_sync,
+        userSync=user_sync,
+    )

--- a/backend/research_vector_store.py
+++ b/backend/research_vector_store.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import importlib
+import os
+from threading import RLock
+from typing import Any, Dict, Iterable, List, Optional
+
+
+DEFAULT_GLOBAL_COLLECTION = "marketmind_global_research_v1"
+DEFAULT_USER_COLLECTION = "marketmind_user_research_v1"
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+_RUNTIME_LOCK = RLock()
+_QDRANT_CLIENT = None
+_QDRANT_MODULE = None
+_QDRANT_MODELS_MODULE = None
+_QDRANT_CLIENT_KEY = None
+
+
+class ResearchVectorStoreError(Exception):
+    pass
+
+
+class ResearchVectorStoreUnavailableError(ResearchVectorStoreError):
+    pass
+
+
+def reset_runtime_state() -> None:
+    global _QDRANT_CLIENT, _QDRANT_MODULE, _QDRANT_MODELS_MODULE, _QDRANT_CLIENT_KEY
+    with _RUNTIME_LOCK:
+        _QDRANT_CLIENT = None
+        _QDRANT_MODULE = None
+        _QDRANT_MODELS_MODULE = None
+        _QDRANT_CLIENT_KEY = None
+
+
+def is_enabled() -> bool:
+    return str(os.getenv("RESEARCH_RETRIEVAL_ENABLED", "")).strip().lower() in TRUE_VALUES
+
+
+def get_qdrant_url() -> str:
+    return str(os.getenv("QDRANT_URL") or "").strip()
+
+
+def get_qdrant_api_key() -> Optional[str]:
+    value = str(os.getenv("QDRANT_API_KEY") or "").strip()
+    return value or None
+
+
+def global_collection_name() -> str:
+    return str(os.getenv("QDRANT_GLOBAL_COLLECTION") or DEFAULT_GLOBAL_COLLECTION).strip()
+
+
+def user_collection_name() -> str:
+    return str(os.getenv("QDRANT_USER_COLLECTION") or DEFAULT_USER_COLLECTION).strip()
+
+
+def _load_qdrant_module():
+    global _QDRANT_MODULE
+    with _RUNTIME_LOCK:
+        if _QDRANT_MODULE is not None:
+            return _QDRANT_MODULE
+        try:
+            _QDRANT_MODULE = importlib.import_module("qdrant_client")
+        except ImportError as exc:
+            raise ResearchVectorStoreUnavailableError(
+                "Qdrant client is not installed for research retrieval."
+            ) from exc
+        return _QDRANT_MODULE
+
+
+def _load_qdrant_models_module():
+    global _QDRANT_MODELS_MODULE
+    with _RUNTIME_LOCK:
+        if _QDRANT_MODELS_MODULE is not None:
+            return _QDRANT_MODELS_MODULE
+        try:
+            _QDRANT_MODELS_MODULE = importlib.import_module("qdrant_client.models")
+        except ImportError as exc:
+            raise ResearchVectorStoreUnavailableError(
+                "Qdrant models are not available for research retrieval."
+            ) from exc
+        return _QDRANT_MODELS_MODULE
+
+
+def _client_cache_key() -> tuple[str, Optional[str]]:
+    return (get_qdrant_url(), get_qdrant_api_key())
+
+
+def _load_client():
+    global _QDRANT_CLIENT, _QDRANT_CLIENT_KEY
+    url = get_qdrant_url()
+    if not url:
+        raise ResearchVectorStoreUnavailableError("Qdrant is not configured.")
+
+    cache_key = _client_cache_key()
+    with _RUNTIME_LOCK:
+        if _QDRANT_CLIENT is not None and _QDRANT_CLIENT_KEY == cache_key:
+            return _QDRANT_CLIENT
+        module = _load_qdrant_module()
+        api_key = get_qdrant_api_key()
+        try:
+            if url in {":memory:", "memory"}:
+                _QDRANT_CLIENT = module.QdrantClient(":memory:")
+            else:
+                _QDRANT_CLIENT = module.QdrantClient(url=url, api_key=api_key)
+        except Exception as exc:
+            raise ResearchVectorStoreUnavailableError(f"Could not connect to Qdrant: {exc}") from exc
+        _QDRANT_CLIENT_KEY = cache_key
+        return _QDRANT_CLIENT
+
+
+def _collection_name_for_scope(scope: str) -> str:
+    normalized_scope = str(scope or "").strip().lower()
+    if normalized_scope == "user":
+        return user_collection_name()
+    return global_collection_name()
+
+
+def ensure_collection(scope: str, vector_size: int) -> str:
+    client = _load_client()
+    models = _load_qdrant_models_module()
+    collection_name = _collection_name_for_scope(scope)
+    try:
+        exists = False
+        collection_exists = getattr(client, "collection_exists", None)
+        if callable(collection_exists):
+            exists = bool(collection_exists(collection_name))
+        else:
+            client.get_collection(collection_name)
+            exists = True
+    except Exception:
+        exists = False
+
+    if exists:
+        return collection_name
+
+    client.create_collection(
+        collection_name=collection_name,
+        vectors_config=models.VectorParams(size=int(vector_size), distance=models.Distance.COSINE),
+    )
+    return collection_name
+
+
+def _build_filter(must: Optional[Dict[str, Any]] = None):
+    must = must or {}
+    models = _load_qdrant_models_module()
+    conditions = []
+    for key, value in must.items():
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set)):
+            values = [item for item in value if item is not None]
+            if not values:
+                continue
+            match_any_cls = getattr(models, "MatchAny", None)
+            if match_any_cls is not None:
+                match = match_any_cls(any=list(values))
+            else:
+                match = models.MatchValue(value=list(values)[0])
+        else:
+            match = models.MatchValue(value=value)
+        conditions.append(models.FieldCondition(key=key, match=match))
+    return models.Filter(must=conditions) if conditions else None
+
+
+def upsert_documents(scope: str, documents: Iterable[Dict[str, Any]], vector_size: int) -> int:
+    docs = [dict(doc or {}) for doc in documents if doc]
+    if not docs:
+        return 0
+    client = _load_client()
+    models = _load_qdrant_models_module()
+    collection_name = ensure_collection(scope, vector_size)
+    points = [
+        models.PointStruct(id=doc["id"], vector=doc["vector"], payload=doc["payload"])
+        for doc in docs
+    ]
+    client.upsert(collection_name=collection_name, points=points, wait=True)
+    return len(points)
+
+
+def query_documents(
+    scope: str,
+    *,
+    query_vector: List[float],
+    limit: int,
+    must_filter: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    client = _load_client()
+    collection_name = _collection_name_for_scope(scope)
+    query_filter = _build_filter(must_filter)
+    try:
+        response = client.search(
+            collection_name=collection_name,
+            query_vector=query_vector,
+            query_filter=query_filter,
+            limit=max(int(limit), 1),
+            with_payload=True,
+        )
+    except Exception:
+        return []
+    results = []
+    for item in response or []:
+        payload = dict(getattr(item, "payload", {}) or {})
+        results.append(
+            {
+                "id": str(getattr(item, "id", "")),
+                "score": float(getattr(item, "score", 0.0)),
+                "payload": payload,
+            }
+        )
+    return results
+
+
+def count_documents(scope: str, *, must_filter: Optional[Dict[str, Any]] = None) -> int:
+    client = _load_client()
+    collection_name = _collection_name_for_scope(scope)
+    query_filter = _build_filter(must_filter)
+    try:
+        response = client.count(collection_name=collection_name, count_filter=query_filter, exact=True)
+    except Exception:
+        return 0
+    return int(getattr(response, "count", 0) or 0)
+
+
+def get_runtime_status() -> Dict[str, Any]:
+    enabled = is_enabled()
+    status = {
+        "enabled": enabled,
+        "available": False,
+        "qdrantUrl": get_qdrant_url() or None,
+        "globalCollection": global_collection_name(),
+        "userCollection": user_collection_name(),
+    }
+    if not enabled:
+        status["reason"] = "disabled"
+        return status
+    try:
+        _load_client()
+        status["available"] = True
+    except ResearchVectorStoreUnavailableError as exc:
+        status["reason"] = str(exc)
+    return status

--- a/backend/tests/test_auth_isolation.py
+++ b/backend/tests/test_auth_isolation.py
@@ -78,6 +78,7 @@ class AuthIsolationTests(unittest.TestCase):
             ("get", "/marketmind-ai/chats", None),
             ("get", "/marketmind-ai/chats/some-id", None),
             ("get", "/marketmind-ai/context?ticker=AAPL", None),
+            ("get", "/marketmind-ai/retrieval-status?ticker=AAPL", None),
             ("post", "/marketmind-ai/chat", {"messages": [{"role": "user", "content": "hello world from user"}]}),
             ("post", "/marketmind-ai/artifacts/preflight", {"templateKey": "investment_thesis_memo", "messages": []}),
             ("get", "/marketmind-ai/artifacts", None),

--- a/backend/tests/test_marketmind_ai_api.py
+++ b/backend/tests/test_marketmind_ai_api.py
@@ -442,6 +442,121 @@ class MarketMindAiApiTests(unittest.TestCase):
             404,
         )
 
+    def test_marketmind_ai_surfaces_retrieved_evidence_and_retrieval_status(self):
+        self._seed_marketmind_context()
+        retrieved_evidence = [
+            {
+                "docType": "sec_section",
+                "title": "10-K · Risk Factors",
+                "snippet": "Supply chain disruption remains a material risk.",
+                "source": "sec",
+                "sourceUrl": "https://www.sec.gov/example-10k",
+                "assetId": "AAPL",
+                "ticker": "AAPL",
+                "score": 0.91,
+                "rank": 1,
+            }
+        ]
+        retrieval_status = {
+            "enabled": True,
+            "available": True,
+            "used": True,
+            "candidateCount": 3,
+            "rerankUsed": True,
+        }
+
+        with patch.object(
+            marketmind_ai_module.research_retrieval_service,
+            "retrieve_for_context",
+            return_value={
+                "retrievedEvidence": retrieved_evidence,
+                "retrievalStatus": retrieval_status,
+            },
+        ), patch.object(
+            marketmind_ai_module.research_retrieval_service,
+            "index_memo_version",
+            return_value={"enabled": True, "available": True, "used": True},
+        ), patch.object(
+            marketmind_ai_module.research_retrieval_service,
+            "get_status_for_context",
+            return_value={
+                "enabled": True,
+                "available": True,
+                "assetId": "AAPL",
+                "ticker": "AAPL",
+                "globalSync": {"docCount": 4},
+                "userSync": {"docCount": 1},
+            },
+        ), patch.object(
+            marketmind_ai_module,
+            "create_chat_completion",
+            return_value={"model": "nvidia/nemotron-3-super-120b-a12b:free", "assistant_text": "Here is the grounded answer with evidence."},
+        ), patch.object(
+            marketmind_ai_module,
+            "create_structured_completion",
+            return_value={
+                "model": "nvidia/nemotron-3-super-120b-a12b:free",
+                "structured_content": {
+                    "executive_summary": "Generated memo preview",
+                    "investment_thesis": "The thesis is grounded in retrieved evidence.",
+                    "supporting_evidence": ["Supply chain disruption remains a material risk."],
+                    "key_assumptions": [],
+                    "risks": [],
+                    "invalidation_conditions": [],
+                    "catalysts": [],
+                    "signals_and_market_context": [],
+                    "linked_positioning": "Current paper portfolio already holds 5 shares.",
+                    "what_would_change_my_mind": "A sharp demand reset.",
+                    "conclusion": "Monitor closely.",
+                },
+            },
+        ), patch.object(
+            marketmind_ai_module,
+            "_render_docx",
+            return_value=b"docx-bytes",
+        ):
+            retrieval_status_response = self.client.get(
+                "/marketmind-ai/retrieval-status?ticker=AAPL",
+                headers=self._auth_headers(),
+            )
+            self.assertEqual(retrieval_status_response.status_code, 200)
+            self.assertEqual(retrieval_status_response.get_json()["assetId"], "AAPL")
+
+            chat_response = self.client.post(
+                "/marketmind-ai/chat",
+                headers=self._auth_headers(),
+                json={
+                    "messages": [{"role": "user", "content": "What is the strongest evidence for Apple right now?"}],
+                    "attachedTicker": "AAPL",
+                },
+            )
+            self.assertEqual(chat_response.status_code, 200)
+            chat_payload = chat_response.get_json()
+            self.assertEqual(chat_payload["retrievedEvidence"][0]["docType"], "sec_section")
+            self.assertTrue(chat_payload["retrievalStatus"]["rerankUsed"])
+
+            artifact_response = self.client.post(
+                "/marketmind-ai/artifacts",
+                headers=self._auth_headers(),
+                json={
+                    "templateKey": "investment_thesis_memo",
+                    "messages": [{"role": "user", "content": "Write a balanced memo for Apple using the current MarketMind context."}],
+                    "attachedTicker": "AAPL",
+                },
+            )
+            self.assertEqual(artifact_response.status_code, 201)
+            artifact_payload = artifact_response.get_json()
+            self.assertEqual(artifact_payload["version"]["retrievedEvidence"][0]["title"], "10-K · Risk Factors")
+            self.assertTrue(artifact_payload["version"]["retrievalStatus"]["used"])
+
+            artifact_detail_response = self.client.get(
+                f"/marketmind-ai/artifacts/{artifact_payload['artifact']['id']}",
+                headers=self._auth_headers(),
+            )
+            self.assertEqual(artifact_detail_response.status_code, 200)
+            detail_payload = artifact_detail_response.get_json()
+            self.assertEqual(detail_payload["versions"][0]["retrievedEvidence"][0]["source"], "sec")
+
     def test_marketmind_ai_recognizes_bitcoin_and_builds_crypto_context(self):
         crypto_quote = {
             "from_crypto": {"code": "BTC", "name": "Bitcoin"},

--- a/backend/tests/test_research_document_builder.py
+++ b/backend/tests/test_research_document_builder.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import research_document_builder as builder
+
+
+class ResearchDocumentBuilderTests(unittest.TestCase):
+    def test_chunk_text_respects_target_and_overlap(self):
+        long_text = "\n\n".join(
+            f"Paragraph {index} " + ("alpha beta gamma " * 40)
+            for index in range(1, 6)
+        )
+        chunks = builder._chunk_text(long_text)
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(all(len(chunk) <= builder.MAX_CHUNK_CHARS for chunk in chunks))
+        self.assertTrue(any(chunks[index][-40:] in chunks[index + 1] for index in range(len(chunks) - 1)))
+
+    def test_build_global_documents_for_us_context_includes_sec_and_news(self):
+        context = {
+            "ticker": "AAPL",
+            "assetId": "AAPL",
+            "market": "US",
+            "assetType": "equity",
+            "recentNews": [
+                {
+                    "title": "Apple news headline",
+                    "publisher": "ExampleWire",
+                    "link": "https://example.com/aapl-news",
+                    "publishedAt": "2026-04-02",
+                }
+            ],
+            "secFilingsSummary": {
+                "accessionNumber": "0000320193-26-000123",
+                "type": "10-K",
+                "date": "2026-01-31",
+                "url": "https://sec.gov/aapl-10k",
+                "sections": [
+                    {
+                        "key": "riskFactors",
+                        "title": "Risk Factors",
+                        "text": "Supply chain disruption remains a material risk.",
+                    }
+                ],
+            },
+            "filingChangeSummary": {
+                "comparisonForm": "10-K",
+                "currentFiling": {"accessionNumber": "0000320193-26-000123", "date": "2026-01-31", "url": "https://sec.gov/aapl-10k"},
+                "sectionChanges": [
+                    {
+                        "key": "managementDiscussion",
+                        "title": "Management Discussion",
+                        "status": "material",
+                        "currentExcerpt": "Demand is improving.",
+                        "previousExcerpt": "Demand was mixed.",
+                    }
+                ],
+            },
+            "insiderActivitySummary": [{"insiderName": "Tim Cook", "type": "4", "activity": "Purchase", "date": "2026-03-01"}],
+            "beneficialOwnershipSummary": [{"owners": ["Berkshire Hathaway"], "type": "SC 13D", "ownershipPercent": 6.8, "date": "2026-03-15"}],
+        }
+
+        documents = builder.build_global_documents(context)
+        doc_types = {doc["payload"]["docType"] for doc in documents}
+        self.assertIn("sec_section", doc_types)
+        self.assertIn("filing_change", doc_types)
+        self.assertIn("insider_activity", doc_types)
+        self.assertIn("beneficial_ownership", doc_types)
+        self.assertIn("news", doc_types)
+        first_payload = documents[0]["payload"]
+        self.assertEqual(first_payload["assetId"], "AAPL")
+        self.assertIn("chunkIndex", first_payload)
+        self.assertIn("chunkCount", first_payload)
+
+    def test_build_global_documents_for_hk_context_includes_announcements_and_macro(self):
+        context = {
+            "ticker": "HK:00700",
+            "assetId": "HK:00700",
+            "market": "HK",
+            "assetType": "equity",
+            "assetName": "Tencent Holdings",
+            "recentNews": [{"title": "Tencent headline", "publisher": "CNInfo", "publishTime": "2026-03-20"}],
+            "companyResearchSummary": {
+                "profile": [{"label": "Company", "value": "Tencent Holdings Limited"}],
+                "announcements": [{"title": "Tencent annual results", "summary": "Results summary", "link": "https://example.com/tencent"}],
+            },
+        }
+        with patch.object(
+            builder.akshare_service,
+            "get_asia_macro_overview",
+            return_value={
+                "indicators": [{"name": "China CPI YoY", "value": 0.7, "unit": "%", "date": "2026-03"}],
+                "marketSignals": [{"name": "USD/CNH", "value": 7.21}],
+            },
+        ):
+            documents = builder.build_global_documents(context)
+
+        doc_types = {doc["payload"]["docType"] for doc in documents}
+        self.assertIn("company_research", doc_types)
+        self.assertIn("announcement", doc_types)
+        self.assertIn("macro_brief", doc_types)
+
+    def test_build_user_memo_documents_includes_sections_and_context(self):
+        memo_row = SimpleNamespace(
+            id="memo-1",
+            version=2,
+            structured_content_json={
+                "executive_summary": "Apple remains durable.",
+                "supporting_evidence": ["Services remain sticky.", "Cash generation is strong."],
+            },
+            context_snapshot_json={
+                "fundamentalsSummary": {"companyName": "Apple Inc.", "sector": "Technology"},
+                "predictionSnapshot": {"recentPredicted": 190.0, "recentClose": 180.0},
+                "retrievedEvidence": [{"title": "Risk Factors", "snippet": "Supply chain risk remains material."}],
+            },
+        )
+        documents = builder.build_user_memo_documents(
+            clerk_user_id="user_a",
+            ticker="AAPL",
+            asset_id="AAPL",
+            market="US",
+            asset_type="equity",
+            memo_rows=[memo_row],
+        )
+        doc_types = {doc["payload"]["docType"] for doc in documents}
+        self.assertIn("memo_section", doc_types)
+        self.assertIn("memo_context", doc_types)
+        self.assertTrue(any(doc["payload"]["clerkUserId"] == "user_a" for doc in documents))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_research_retrieval_service.py
+++ b/backend/tests/test_research_retrieval_service.py
@@ -1,0 +1,292 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import api as backend_api
+import research_retrieval_service as retrieval_service
+from user_state_store import reset_runtime_state
+
+
+class ResearchRetrievalServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_root = self.tmpdir.name
+        self.state_db_path = os.path.join(self.tmp_root, "user_state.db")
+
+        self.original_state = {
+            "BASE_DIR": backend_api.BASE_DIR,
+            "DATABASE": backend_api.DATABASE,
+            "DATABASE_URL": backend_api.DATABASE_URL,
+            "PERSISTENCE_MODE": backend_api.PERSISTENCE_MODE,
+            "USER_DATA_DIR": backend_api.USER_DATA_DIR,
+            "PORTFOLIO_FILE": backend_api.PORTFOLIO_FILE,
+            "NOTIFICATIONS_FILE": backend_api.NOTIFICATIONS_FILE,
+            "PREDICTION_PORTFOLIO_FILE": backend_api.PREDICTION_PORTFOLIO_FILE,
+            "ALLOW_LEGACY_USER_DATA_SEED": backend_api.ALLOW_LEGACY_USER_DATA_SEED,
+            "RESEARCH_RETRIEVAL_ENABLED": os.environ.get("RESEARCH_RETRIEVAL_ENABLED"),
+            "QDRANT_URL": os.environ.get("QDRANT_URL"),
+        }
+
+        reset_runtime_state()
+        retrieval_service.reset_runtime_state()
+        backend_api.BASE_DIR = self.tmp_root
+        backend_api.DATABASE = os.path.join(self.tmp_root, "marketmind_test.db")
+        backend_api.DATABASE_URL = f"sqlite:///{self.state_db_path}"
+        backend_api.PERSISTENCE_MODE = "postgres"
+        backend_api.USER_DATA_DIR = os.path.join(self.tmp_root, "user_data")
+        backend_api.PORTFOLIO_FILE = os.path.join(self.tmp_root, "paper_portfolio.json")
+        backend_api.NOTIFICATIONS_FILE = os.path.join(self.tmp_root, "notifications.json")
+        backend_api.PREDICTION_PORTFOLIO_FILE = os.path.join(self.tmp_root, "prediction_portfolio.json")
+        backend_api.ALLOW_LEGACY_USER_DATA_SEED = False
+        os.makedirs(backend_api.USER_DATA_DIR, exist_ok=True)
+        backend_api.init_db()
+        os.environ["RESEARCH_RETRIEVAL_ENABLED"] = "true"
+        os.environ["QDRANT_URL"] = ":memory:"
+
+    def tearDown(self):
+        backend_api.BASE_DIR = self.original_state["BASE_DIR"]
+        backend_api.DATABASE = self.original_state["DATABASE"]
+        backend_api.DATABASE_URL = self.original_state["DATABASE_URL"]
+        backend_api.PERSISTENCE_MODE = self.original_state["PERSISTENCE_MODE"]
+        backend_api.USER_DATA_DIR = self.original_state["USER_DATA_DIR"]
+        backend_api.PORTFOLIO_FILE = self.original_state["PORTFOLIO_FILE"]
+        backend_api.NOTIFICATIONS_FILE = self.original_state["NOTIFICATIONS_FILE"]
+        backend_api.PREDICTION_PORTFOLIO_FILE = self.original_state["PREDICTION_PORTFOLIO_FILE"]
+        backend_api.ALLOW_LEGACY_USER_DATA_SEED = self.original_state["ALLOW_LEGACY_USER_DATA_SEED"]
+        if self.original_state["RESEARCH_RETRIEVAL_ENABLED"] is None:
+            os.environ.pop("RESEARCH_RETRIEVAL_ENABLED", None)
+        else:
+            os.environ["RESEARCH_RETRIEVAL_ENABLED"] = self.original_state["RESEARCH_RETRIEVAL_ENABLED"]
+        if self.original_state["QDRANT_URL"] is None:
+            os.environ.pop("QDRANT_URL", None)
+        else:
+            os.environ["QDRANT_URL"] = self.original_state["QDRANT_URL"]
+        retrieval_service.reset_runtime_state()
+        reset_runtime_state()
+        self.tmpdir.cleanup()
+
+    def _context(self, ticker="AAPL", market="US"):
+        context = {
+            "ticker": ticker,
+            "assetId": ticker if market == "US" else f"{market}:{ticker}",
+            "market": market,
+            "assetType": "equity",
+            "recentNews": [{"title": f"{ticker} headline", "publisher": "ExampleWire", "publishedAt": "2026-04-02"}],
+            "fundamentalsSummary": {"companyName": f"{ticker} Corp", "sector": "Technology"},
+        }
+        if market == "US":
+            context.update(
+                {
+                    "secFilingsSummary": {
+                        "accessionNumber": "0000000000-26-000001",
+                        "type": "10-K",
+                        "date": "2026-01-31",
+                        "url": "https://sec.gov/example",
+                        "sections": [{"key": "riskFactors", "title": "Risk Factors", "text": "Demand could soften."}],
+                    },
+                    "filingChangeSummary": {
+                        "comparisonForm": "10-K",
+                        "currentFiling": {"accessionNumber": "0000000000-26-000001", "date": "2026-01-31"},
+                        "sectionChanges": [{"key": "managementDiscussion", "title": "Management Discussion", "status": "material", "currentExcerpt": "Growth improved."}],
+                    },
+                    "insiderActivitySummary": [{"insiderName": "CEO", "type": "4", "activity": "Purchase"}],
+                    "beneficialOwnershipSummary": [{"owners": ["Holder"], "type": "SC 13D", "ownershipPercent": 6.8}],
+                }
+            )
+        else:
+            context.update(
+                {
+                    "assetName": "Tencent Holdings",
+                    "companyResearchSummary": {
+                        "profile": [{"label": "Company", "value": "Tencent Holdings Limited"}],
+                        "announcements": [{"title": "Tencent annual results", "summary": "Strong results", "link": "https://example.com/tencent"}],
+                    },
+                }
+            )
+        return context
+
+    def test_retrieve_for_context_returns_dense_candidates_and_reranks_us_equities(self):
+        with patch.object(retrieval_service.research_embedding_service, "get_runtime_status", return_value={"available": True}), patch.object(
+            retrieval_service.research_vector_store,
+            "get_runtime_status",
+            return_value={"available": True},
+        ), patch.object(
+            retrieval_service.research_embedding_service,
+            "encode_documents",
+            return_value=[[0.1, 0.2], [0.2, 0.3], [0.3, 0.4]],
+        ), patch.object(
+            retrieval_service.research_embedding_service,
+            "encode_query",
+            return_value=[0.1, 0.2],
+        ), patch.object(
+            retrieval_service.research_vector_store,
+            "upsert_documents",
+            side_effect=lambda scope, documents, vector_size: len(list(documents)),
+        ), patch.object(
+            retrieval_service.research_vector_store,
+            "count_documents",
+            return_value=3,
+        ), patch.object(
+            retrieval_service.research_vector_store,
+            "query_documents",
+            side_effect=[
+                [
+                    {
+                        "id": "global-1",
+                        "score": 0.62,
+                        "payload": {
+                            "docType": "news",
+                            "title": "AAPL headline",
+                            "snippet": "Headline snippet",
+                            "text": "Headline snippet",
+                            "source": "news",
+                            "sourceUrl": "https://example.com/news",
+                            "assetId": "AAPL",
+                            "ticker": "AAPL",
+                            "market": "US",
+                            "language": "en",
+                        },
+                    }
+                ],
+                [
+                    {
+                        "id": "user-1",
+                        "score": 0.51,
+                        "payload": {
+                            "docType": "memo_section",
+                            "title": "Memo v1 executive summary",
+                            "snippet": "Memo snippet",
+                            "text": "Memo snippet",
+                            "source": "memo",
+                            "assetId": "AAPL",
+                            "ticker": "AAPL",
+                            "market": "US",
+                            "language": "en",
+                        },
+                    }
+                ],
+            ],
+        ), patch.object(
+            retrieval_service.research_embedding_service,
+            "rerank_documents",
+            side_effect=lambda query, documents, allow_rerank=True: [
+                {**documents[1], "rerankScore": 0.93},
+                {**documents[0], "rerankScore": 0.72},
+            ],
+        ):
+            with backend_api.user_state_session_scope(backend_api.DATABASE_URL) as session:
+                payload = retrieval_service.retrieve_for_context(
+                    session,
+                    "user_a",
+                    query_text="What are the main risks for Apple?",
+                    context=self._context(),
+                )
+
+        self.assertTrue(payload["retrievalStatus"]["used"])
+        self.assertTrue(payload["retrievalStatus"]["rerankUsed"])
+        self.assertEqual(len(payload["retrievedEvidence"]), 2)
+        self.assertEqual(payload["retrievedEvidence"][0]["docType"], "memo_section")
+
+    def test_retrieve_for_context_skips_rerank_for_hk_assets(self):
+        with patch.object(retrieval_service.research_embedding_service, "get_runtime_status", return_value={"available": True}), patch.object(
+            retrieval_service.research_vector_store,
+            "get_runtime_status",
+            return_value={"available": True},
+        ), patch.object(
+            retrieval_service.research_embedding_service,
+            "encode_documents",
+            return_value=[[0.1, 0.2], [0.2, 0.3]],
+        ), patch.object(
+            retrieval_service.research_embedding_service,
+            "encode_query",
+            return_value=[0.1, 0.2],
+        ), patch.object(
+            retrieval_service.research_vector_store,
+            "upsert_documents",
+            side_effect=lambda scope, documents, vector_size: len(list(documents)),
+        ), patch.object(
+            retrieval_service.research_vector_store,
+            "count_documents",
+            return_value=2,
+        ), patch.object(
+            retrieval_service.research_vector_store,
+            "query_documents",
+            side_effect=[
+                [
+                    {
+                        "id": "global-1",
+                        "score": 0.62,
+                        "payload": {
+                            "docType": "announcement",
+                            "title": "Tencent annual results",
+                            "snippet": "Results summary",
+                            "text": "Results summary",
+                            "source": "akshare",
+                            "sourceUrl": "https://example.com/tencent",
+                            "assetId": "HK:00700",
+                            "ticker": "HK:00700",
+                            "market": "HK",
+                            "language": "zh",
+                        },
+                    }
+                ],
+                [],
+            ],
+        ), patch.object(
+            retrieval_service.research_embedding_service,
+            "rerank_documents",
+            side_effect=AssertionError("HK retrieval should not rerank"),
+        ):
+            with backend_api.user_state_session_scope(backend_api.DATABASE_URL) as session:
+                payload = retrieval_service.retrieve_for_context(
+                    session,
+                    "user_a",
+                    query_text="What matters most for Tencent?",
+                    context=self._context(ticker="00700", market="HK"),
+                )
+
+        self.assertTrue(payload["retrievalStatus"]["used"])
+        self.assertFalse(payload["retrievalStatus"].get("rerankUsed"))
+        self.assertEqual(payload["retrievedEvidence"][0]["docType"], "announcement")
+
+    def test_retrieve_for_compare_groups_results_by_ticker(self):
+        with patch.object(
+            retrieval_service,
+            "_retrieve_candidates_for_context",
+            side_effect=[
+                {"evidence": [{"docType": "sec_section", "ticker": "MSFT", "title": "MSFT filing", "snippet": "MSFT snippet", "source": "sec", "assetId": "MSFT", "rank": 1}], "status": {"available": True, "used": True}},
+                {"evidence": [{"docType": "sec_section", "ticker": "GOOGL", "title": "GOOGL filing", "snippet": "GOOGL snippet", "source": "sec", "assetId": "GOOGL", "rank": 1}], "status": {"available": True, "used": True}},
+            ],
+        ):
+            with backend_api.user_state_session_scope(backend_api.DATABASE_URL) as session:
+                payload = retrieval_service.retrieve_for_compare(
+                    session,
+                    "user_a",
+                    query_text="Compare Microsoft versus Google on the latest evidence.",
+                    contexts=[self._context(ticker="MSFT"), self._context(ticker="GOOGL")],
+                )
+
+        self.assertEqual([item["ticker"] for item in payload["retrievedEvidence"]], ["GOOGL", "MSFT"])
+        self.assertTrue(payload["retrievalStatus"]["compare"])
+        self.assertEqual(len(payload["retrievalStatus"]["groups"]), 2)
+
+    def test_retrieval_disabled_falls_back_cleanly(self):
+        os.environ["RESEARCH_RETRIEVAL_ENABLED"] = "false"
+        with backend_api.user_state_session_scope(backend_api.DATABASE_URL) as session:
+            payload = retrieval_service.retrieve_for_context(
+                session,
+                "user_a",
+                query_text="What are the main risks for Apple?",
+                context=self._context(),
+            )
+        self.assertFalse(payload["retrievalStatus"]["enabled"])
+        self.assertEqual(payload["retrievedEvidence"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_route_registration_smoke.py
+++ b/backend/tests/test_route_registration_smoke.py
@@ -20,6 +20,7 @@ class RouteRegistrationSmokeTests(unittest.TestCase):
             "/marketmind-ai/chats": {"GET"},
             "/marketmind-ai/chats/<string:chat_id>": {"GET", "DELETE"},
             "/marketmind-ai/context": {"GET"},
+            "/marketmind-ai/retrieval-status": {"GET"},
             "/marketmind-ai/chat": {"POST"},
             "/marketmind-ai/artifacts/preflight": {"POST"},
             "/marketmind-ai/artifacts": {"GET", "POST"},

--- a/frontend/src/components/MarketMindAIPage.js
+++ b/frontend/src/components/MarketMindAIPage.js
@@ -156,6 +156,71 @@ const ContextCard = ({ label, value, caption }) => (
     </div>
 );
 
+const EvidencePanel = ({ title = 'Retrieved evidence', items = [], status = null }) => {
+    const hasItems = Array.isArray(items) && items.length > 0;
+    const unavailable = status && status.enabled && !status.available;
+    const empty = status && status.available && !hasItems && status.reason === 'no_relevant_documents';
+
+    if (!hasItems && !unavailable && !empty) {
+        return null;
+    }
+
+    return (
+        <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
+            <div className="flex items-center justify-between gap-3">
+                <div>
+                    <SectionLabel>{title}</SectionLabel>
+                    <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+                        {hasItems
+                            ? 'MarketMindAI used stored research evidence alongside the live ticker context.'
+                            : unavailable
+                            ? 'Research retrieval is temporarily unavailable, so MarketMindAI answered from the live context only.'
+                            : 'No stored research evidence matched this request yet, so MarketMindAI answered from the live context only.'}
+                    </p>
+                </div>
+                {status?.rerankUsed ? (
+                    <span className="inline-flex rounded-full bg-slate-950 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white dark:bg-slate-100 dark:text-slate-950">
+                        reranked
+                    </span>
+                ) : null}
+            </div>
+            {hasItems ? (
+                <div className="mt-4 space-y-3">
+                    {items.map((item, index) => (
+                        <div key={`${item.assetId || item.title || 'evidence'}-${index}`} className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+                            <div className="flex flex-wrap items-center gap-2">
+                                {item.docType ? (
+                                    <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                                        {item.docType}
+                                    </span>
+                                ) : null}
+                                {item.ticker ? (
+                                    <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                                        {item.ticker}
+                                    </span>
+                                ) : null}
+                                {item.source ? <span className="text-xs text-slate-400 dark:text-slate-500">{item.source}</span> : null}
+                            </div>
+                            <p className="mt-3 text-sm font-semibold text-slate-950 dark:text-white">{item.title || 'Untitled evidence'}</p>
+                            <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">{item.snippet || 'No snippet available.'}</p>
+                            {item.sourceUrl ? (
+                                <a
+                                    href={item.sourceUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="mt-3 inline-flex text-sm font-medium text-sky-700 transition hover:text-sky-600 dark:text-sky-300 dark:hover:text-sky-200"
+                                >
+                                    Open source
+                                </a>
+                            ) : null}
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    );
+};
+
 const ArtifactPreview = ({ artifact, version }) => {
     if (!artifact || !version) {
         return (
@@ -224,6 +289,8 @@ const MarketMindAIPage = () => {
     const [composerValue, setComposerValue] = useState('');
     const [chatLoading, setChatLoading] = useState(false);
     const [generatingArtifact, setGeneratingArtifact] = useState(false);
+    const [retrievedEvidence, setRetrievedEvidence] = useState([]);
+    const [retrievalStatus, setRetrievalStatus] = useState(null);
     const [preflight, setPreflight] = useState(null);
     const [pageError, setPageError] = useState('');
     const [workspaceNotice, setWorkspaceNotice] = useState(null);
@@ -322,6 +389,8 @@ const MarketMindAIPage = () => {
                 }))
             );
             setComposerValue('');
+            setRetrievedEvidence([]);
+            setRetrievalStatus(null);
             setWorkspaceNotice(null);
             setPreflight(null);
             const nextTicker = payload.chat?.attachedTicker || '';
@@ -385,6 +454,8 @@ const MarketMindAIPage = () => {
                 setComposerValue('');
                 setAttachedTicker('');
                 setContextData(null);
+                setRetrievedEvidence([]);
+                setRetrievalStatus(null);
                 setPreflight(null);
                 setWorkspaceNotice(null);
                 setPageError('');
@@ -425,6 +496,8 @@ const MarketMindAIPage = () => {
         setComposerValue('');
         setAttachedTicker('');
         setContextData(null);
+        setRetrievedEvidence([]);
+        setRetrievalStatus(null);
         setPreflight(null);
         setWorkspaceNotice(null);
         setPageError('');
@@ -501,6 +574,8 @@ const MarketMindAIPage = () => {
         setWorkspaceNotice(null);
         setPageError('');
         setPreflight(null);
+        setRetrievedEvidence([]);
+        setRetrievalStatus(null);
 
         try {
             const payload = await apiRequest(API_ENDPOINTS.MARKETMIND_AI_CHAT, {
@@ -523,6 +598,8 @@ const MarketMindAIPage = () => {
                 setActiveChatId(payload.chat.id);
                 announceHistoryUpdated();
             }
+            setRetrievedEvidence(payload.retrievedEvidence || []);
+            setRetrievalStatus(payload.retrievalStatus || null);
 
             const resolution = payload.tickerResolution || {};
             const comparePair = Array.isArray(payload.comparePair) ? payload.comparePair : [];
@@ -772,6 +849,13 @@ const MarketMindAIPage = () => {
                                 </div>
                             ) : null}
 
+                            <div className="mt-4">
+                                <EvidencePanel
+                                    items={retrievedEvidence}
+                                    status={retrievalStatus}
+                                />
+                            </div>
+
                             <div className="mt-5 rounded-[24px] border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
                                 <div className="flex flex-col gap-3 md:flex-row md:items-end">
                                     <div className="min-w-0 flex-1">
@@ -858,6 +942,15 @@ const MarketMindAIPage = () => {
                             </div>
 
                             <div className="px-5 py-5">
+                                {selectedVersion?.retrievedEvidence?.length || selectedVersion?.retrievalStatus ? (
+                                    <div className="mb-5">
+                                        <EvidencePanel
+                                            title="Memo evidence"
+                                            items={selectedVersion?.retrievedEvidence || []}
+                                            status={selectedVersion?.retrievalStatus || null}
+                                        />
+                                    </div>
+                                ) : null}
                                 {artifactLoading ? (
                                     <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-400">
                                         Loading artifact...

--- a/frontend/src/components/MarketMindAIPage.test.js
+++ b/frontend/src/components/MarketMindAIPage.test.js
@@ -43,6 +43,23 @@ const artifactDetailPayload = {
             version: 1,
             generationStatus: 'completed',
             hasArtifact: true,
+            retrievedEvidence: [
+                {
+                    docType: 'sec_section',
+                    title: '10-K · Risk Factors',
+                    snippet: 'Supply chain disruption remains a material risk.',
+                    source: 'sec',
+                    sourceUrl: 'https://www.sec.gov/example-10k',
+                    assetId: 'AAPL',
+                    ticker: 'AAPL',
+                },
+            ],
+            retrievalStatus: {
+                enabled: true,
+                available: true,
+                used: true,
+                rerankUsed: true,
+            },
             structuredContent: {
                 executive_summary: 'Generated memo preview',
                 investment_thesis: 'The thesis is grounded in current context.',
@@ -126,6 +143,23 @@ describe('MarketMindAIPage', () => {
                             '| Valuation | Premium multiple creates downside if growth slows. |',
                         ].join('\n'),
                     },
+                    retrievedEvidence: [
+                        {
+                            docType: 'sec_section',
+                            title: '10-K · Risk Factors',
+                            snippet: 'Supply chain disruption remains a material risk.',
+                            source: 'sec',
+                            sourceUrl: 'https://www.sec.gov/example-10k',
+                            assetId: 'NVDA',
+                            ticker: 'NVDA',
+                        },
+                    ],
+                    retrievalStatus: {
+                        enabled: true,
+                        available: true,
+                        used: true,
+                        rerankUsed: true,
+                    },
                     suggestedActions: [],
                     artifactIntent: {
                         templateKey: 'investment_thesis_memo',
@@ -208,6 +242,8 @@ describe('MarketMindAIPage', () => {
         expect((await screen.findAllByText(/Summarize the current setup for NVDA using predictions, news, and fundamentals\./i)).length).toBeGreaterThan(0);
         expect(await screen.findByText('Market session')).toBeInTheDocument();
         expect(screen.getByText('Open')).toBeInTheDocument();
+        expect(await screen.findByText(/Retrieved evidence/i)).toBeInTheDocument();
+        expect((await screen.findAllByText(/10-K · Risk Factors/i)).length).toBeGreaterThan(0);
 
         await waitFor(() => {
             expect(apiRequest).toHaveBeenCalledWith(
@@ -218,6 +254,7 @@ describe('MarketMindAIPage', () => {
 
         expect((await screen.findAllByText(/Investment Thesis Memo/i)).length).toBeGreaterThan(0);
         expect(await screen.findByText(/Generated memo preview/i)).toBeInTheDocument();
+        expect(await screen.findByText(/Memo evidence/i)).toBeInTheDocument();
     });
 
     test('reconciles a stale saved ticker with the backend-resolved ticker and closes mismatched artifacts', async () => {

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -96,6 +96,8 @@ export const API_ENDPOINTS = {
     MARKETMIND_AI_CHAT_DELETE: (chatId) => `${API_BASE_URL}/marketmind-ai/chats/${chatId}`,
     MARKETMIND_AI_CONTEXT: (ticker, market = 'us') =>
         buildApiUrl('/marketmind-ai/context', withOptionalMarket({ ticker }, market)),
+    MARKETMIND_AI_RETRIEVAL_STATUS: (ticker, market = 'us') =>
+        buildApiUrl('/marketmind-ai/retrieval-status', withOptionalMarket({ ticker }, market)),
     MARKETMIND_AI_CHAT: `${API_BASE_URL}/marketmind-ai/chat`,
     MARKETMIND_AI_ARTIFACT_PREFLIGHT: `${API_BASE_URL}/marketmind-ai/artifacts/preflight`,
     MARKETMIND_AI_ARTIFACTS: `${API_BASE_URL}/marketmind-ai/artifacts`,

--- a/frontend/src/config/api.test.js
+++ b/frontend/src/config/api.test.js
@@ -65,6 +65,9 @@ describe('API_ENDPOINTS', () => {
         expect(API_ENDPOINTS.MARKETMIND_AI_CONTEXT('HK:00700', 'HK')).toBe(
             `${API_BASE_URL}/marketmind-ai/context?ticker=HK%3A00700&market=hk`
         );
+        expect(API_ENDPOINTS.MARKETMIND_AI_RETRIEVAL_STATUS('HK:00700', 'HK')).toBe(
+            `${API_BASE_URL}/marketmind-ai/retrieval-status?ticker=HK%3A00700&market=hk`
+        );
     });
 
     test('builds the SEC intelligence endpoint for fundamentals research', () => {


### PR DESCRIPTION
## Summary
- add a retrieval evidence layer for MarketMindAI replies and memo generation using SentenceTransformers and Qdrant
- index SEC, news, Akshare, macro, and saved memo evidence into filtered global and user-scoped vector collections
- surface retrieved evidence in MarketMindAI responses, stored memo context snapshots, and the MarketMindAI UI

## Testing
- backend/.venv/bin/python -m unittest -v backend.tests.test_user_journey_harness
- PYTHON_BIN=/Users/tazeemmahashin/MarketMind/backend/.venv/bin/python bash backend/run_deterministic_backend_checks.sh
- backend/.venv/bin/python -m unittest -v backend.tests.test_research_document_builder backend.tests.test_research_retrieval_service backend.tests.test_marketmind_ai_api backend.tests.test_route_registration_smoke backend.tests.test_auth_isolation
- bash frontend/run_frontend_checks.sh

## Notes
- retrieval is gated behind RESEARCH_RETRIEVAL_ENABLED and falls back cleanly when Qdrant or model weights are unavailable
- local runtime import verification passed for sentence-transformers 5.2.3 and qdrant-client 1.17.0