### PR TITLE
feat(screener): upgrade screener experience

### DIFF
--- a/frontend/src/components/ScreenerPage.js
+++ b/frontend/src/components/ScreenerPage.js
@@ -1,51 +1,193 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { TrendingUp, TrendingDown, Activity, ArrowUpDown, ExternalLink } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+    Activity,
+    ArrowUpDown,
+    ChevronLeft,
+    ChevronRight,
+    ExternalLink,
+    RefreshCw,
+    SlidersHorizontal,
+    TrendingDown,
+    TrendingUp,
+} from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
-const TABS = [
-    { key: 'gainers', label: 'Top Gainers',   icon: TrendingUp,   color: 'text-green-600 dark:text-green-400' },
-    { key: 'losers',  label: 'Top Losers',    icon: TrendingDown, color: 'text-red-600 dark:text-red-400'   },
-    { key: 'active',  label: 'Most Active',   icon: Activity,     color: 'text-blue-600 dark:text-blue-400' },
+const PRIMARY_PRESETS = [
+    { key: 'gainers', label: 'Top Gainers', icon: TrendingUp, color: 'text-green-600 dark:text-green-400' },
+    { key: 'losers', label: 'Top Losers', icon: TrendingDown, color: 'text-red-600 dark:text-red-400' },
+    { key: 'active', label: 'Most Active', icon: Activity, color: 'text-blue-600 dark:text-blue-400' },
 ];
 
-const fmt = (n, prefix = '', suffix = '') => {
-    if (n === null || n === undefined) return '—';
-    const abs = Math.abs(n);
-    if (abs >= 1e12) return `${prefix}${(n / 1e12).toFixed(2)}T${suffix}`;
-    if (abs >= 1e9)  return `${prefix}${(n / 1e9).toFixed(2)}B${suffix}`;
-    if (abs >= 1e6)  return `${prefix}${(n / 1e6).toFixed(2)}M${suffix}`;
-    return `${prefix}${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}${suffix}`;
+const DEFAULT_SCAN_LIMIT = 25;
+
+const formatCompactNumber = (value, prefix = '', suffix = '') => {
+    if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+    const numeric = Number(value);
+    const abs = Math.abs(numeric);
+    if (abs >= 1e12) return `${prefix}${(numeric / 1e12).toFixed(2)}T${suffix}`;
+    if (abs >= 1e9) return `${prefix}${(numeric / 1e9).toFixed(2)}B${suffix}`;
+    if (abs >= 1e6) return `${prefix}${(numeric / 1e6).toFixed(2)}M${suffix}`;
+    return `${prefix}${numeric.toLocaleString(undefined, { maximumFractionDigits: 2 })}${suffix}`;
 };
 
+const formatPercent = (value, scale = 1) => {
+    if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+    return `${(Number(value) * scale).toFixed(2)}%`;
+};
+
+const formatDateTime = (value) => {
+    if (!value) return '—';
+    try {
+        return new Date(value).toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+        });
+    } catch (_error) {
+        return value;
+    }
+};
+
+const blankFilters = {
+    query: '',
+    priceMin: '',
+    priceMax: '',
+    marketCapMin: '',
+    avgDollarVolumeMin: '',
+    sector: '',
+};
+
+const columns = [
+    { key: 'symbol', label: 'Symbol' },
+    { key: 'price', label: 'Price' },
+    { key: 'percent_change', label: 'Change %', isPercent: true, scale: 100 },
+    { key: 'market_cap', label: 'Mkt Cap', formatter: (value) => formatCompactNumber(value, '$') },
+    { key: 'avg_dollar_volume_30d', label: 'Avg $ Vol', formatter: (value) => formatCompactNumber(value, '$') },
+    { key: 'relative_volume_20d', label: 'Rel Vol', formatter: (value) => (value === null || value === undefined ? '—' : Number(value).toFixed(2)) },
+    { key: 'momentum_3m', label: '3M', isPercent: true, scale: 100 },
+    { key: 'pe_forward', label: 'Fwd P/E', formatter: (value) => (value === null || value === undefined ? '—' : Number(value).toFixed(1)) },
+    { key: 'year_high', label: '52W High', formatter: (value) => (value === null || value === undefined ? '—' : `$${Number(value).toFixed(2)}`) },
+    { key: 'year_low', label: '52W Low', formatter: (value) => (value === null || value === undefined ? '—' : `$${Number(value).toFixed(2)}`) },
+];
+
 const ScreenerPage = ({ onSearchTicker }) => {
-    const [activeTab, setActiveTab] = useState('gainers');
-    const [data, setData] = useState(null);
+    const [presets, setPresets] = useState([]);
+    const [sectors, setSectors] = useState([]);
+    const [activePreset, setActivePreset] = useState('gainers');
+    const [sortConfig, setSortConfig] = useState({ key: 'percent_change', dir: 'desc' });
+    const [rows, setRows] = useState([]);
+    const [meta, setMeta] = useState({});
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
-    const [sortConfig, setSortConfig] = useState({ key: 'percent_change', dir: 'desc' });
+    const [draftFilters, setDraftFilters] = useState(blankFilters);
+    const [appliedFilters, setAppliedFilters] = useState(blankFilters);
+    const [offset, setOffset] = useState(0);
 
     useEffect(() => {
-        setLoading(true);
-        apiRequest(API_ENDPOINTS.SCREENER())
-            .then(d => { setData(d); setLoading(false); })
-            .catch(() => { setError('Failed to load screener data.'); setLoading(false); });
+        let cancelled = false;
+
+        const loadPresets = async () => {
+            try {
+                const payload = await apiRequest(API_ENDPOINTS.SCREENER_PRESETS);
+                if (cancelled) return;
+                setPresets(payload?.presets || []);
+                setSectors(payload?.sectors || []);
+            } catch (requestError) {
+                if (cancelled) return;
+                console.error('Failed to load screener presets:', requestError);
+                setPresets([]);
+                setSectors([]);
+            }
+        };
+
+        loadPresets();
+        return () => {
+            cancelled = true;
+        };
     }, []);
 
-    const rows = useMemo(() => {
-        if (!data || !data[activeTab]) return [];
-        const list = [...data[activeTab]];
-        list.sort((a, b) => {
-            const av = a[sortConfig.key] ?? -Infinity;
-            const bv = b[sortConfig.key] ?? -Infinity;
-            return sortConfig.dir === 'asc' ? av - bv : bv - av;
+    const presetMap = useMemo(
+        () => Object.fromEntries((presets || []).map((preset) => [preset.key, preset])),
+        [presets],
+    );
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const loadScan = async () => {
+            setLoading(true);
+            setError('');
+            try {
+                const payload = await apiRequest(API_ENDPOINTS.SCREENER_SCAN({
+                    preset: activePreset,
+                    query: appliedFilters.query,
+                    price_min: appliedFilters.priceMin,
+                    price_max: appliedFilters.priceMax,
+                    market_cap_min: appliedFilters.marketCapMin,
+                    avg_dollar_volume_min: appliedFilters.avgDollarVolumeMin,
+                    sector: appliedFilters.sector,
+                    sort: sortConfig.key,
+                    dir: sortConfig.dir,
+                    limit: DEFAULT_SCAN_LIMIT,
+                    offset,
+                }));
+                if (cancelled) return;
+                setRows(payload?.rows || []);
+                setMeta(payload?.meta || {});
+                if (Array.isArray(payload?.filters?.availableSectors) && payload.filters.availableSectors.length) {
+                    setSectors(payload.filters.availableSectors);
+                }
+            } catch (requestError) {
+                if (cancelled) return;
+                console.error('Failed to load screener scan:', requestError);
+                setRows([]);
+                setMeta({});
+                setError('Failed to load screener data.');
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        loadScan();
+        return () => {
+            cancelled = true;
+        };
+    }, [activePreset, appliedFilters, sortConfig, offset]);
+
+    const secondaryPresets = presets.filter((preset) => !PRIMARY_PRESETS.some((item) => item.key === preset.key));
+    const total = Number(meta?.total || 0);
+    const currentPage = Math.floor(offset / DEFAULT_SCAN_LIMIT) + 1;
+    const totalPages = Math.max(1, Math.ceil(total / DEFAULT_SCAN_LIMIT));
+
+    const applyFilters = () => {
+        setOffset(0);
+        setAppliedFilters(draftFilters);
+    };
+
+    const clearFilters = () => {
+        setDraftFilters(blankFilters);
+        setAppliedFilters(blankFilters);
+        setOffset(0);
+    };
+
+    const handlePresetChange = (presetKey) => {
+        const preset = presetMap[presetKey];
+        setActivePreset(presetKey);
+        setOffset(0);
+        setSortConfig({
+            key: preset?.defaultSort || (presetKey === 'active' ? 'relative_volume_20d' : 'percent_change'),
+            dir: preset?.defaultDir || (presetKey === 'losers' ? 'asc' : 'desc'),
         });
-        return list;
-    }, [data, activeTab, sortConfig]);
+    };
 
     const requestSort = (key) => {
-        setSortConfig(prev => ({
+        setOffset(0);
+        setSortConfig((current) => ({
             key,
-            dir: prev.key === key && prev.dir === 'desc' ? 'asc' : 'desc',
+            dir: current.key === key && current.dir === 'desc' ? 'asc' : 'desc',
         }));
     };
 
@@ -66,38 +208,149 @@ const ScreenerPage = ({ onSearchTicker }) => {
 
     return (
         <div className="ui-page animate-fade-in">
-            {/* Header */}
             <div className="ui-page-header">
-                <h1 className="ui-page-title">Stock Screener</h1>
-                <p className="ui-page-subtitle mt-1">
-                    Live market movers — click any row to research the stock
-                </p>
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h1 className="ui-page-title">Stock Screener</h1>
+                        <p className="ui-page-subtitle mt-1">
+                            Internal U.S. equity discovery with cached market movers, momentum, and liquidity screens.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        className="ui-button-secondary flex items-center gap-2"
+                        onClick={() => {
+                            setOffset(0);
+                            setAppliedFilters((current) => ({ ...current }));
+                        }}
+                    >
+                        <RefreshCw className="w-4 h-4" />
+                        Refresh
+                    </button>
+                </div>
             </div>
 
-            {/* Tabs */}
-            <div className="flex gap-2 mb-6">
-                {TABS.map(({ key, label, icon: Icon, color }) => (
+            <div className="flex flex-wrap gap-2 mb-4">
+                {PRIMARY_PRESETS.map(({ key, label, icon: Icon, color }) => (
                     <button
                         key={key}
-                        onClick={() => { setActiveTab(key); setSortConfig({ key: 'percent_change', dir: key === 'active' ? 'desc' : (key === 'losers' ? 'asc' : 'desc') }); }}
+                        onClick={() => handlePresetChange(key)}
                         className={`flex items-center gap-2 px-4 py-2 text-sm transition-colors ${
-                            activeTab === key
-                                ? 'ui-button-primary'
-                                : 'ui-button-secondary'
+                            activePreset === key ? 'ui-button-primary' : 'ui-button-secondary'
                         }`}
                     >
-                        <Icon className={`w-4 h-4 ${activeTab === key ? 'text-white' : color}`} />
+                        <Icon className={`w-4 h-4 ${activePreset === key ? 'text-white' : color}`} />
                         {label}
                     </button>
                 ))}
             </div>
 
-            {/* Table */}
+            {secondaryPresets.length > 0 && (
+                <div className="ui-panel p-4 mb-4">
+                    <div className="flex items-center gap-2 mb-3">
+                        <SlidersHorizontal className="w-4 h-4 text-mm-accent-primary" />
+                        <p className="ui-section-label mb-0">Discovery Presets</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        {secondaryPresets.map((preset) => (
+                            <button
+                                key={preset.key}
+                                type="button"
+                                className={`px-3 py-2 rounded-control text-sm border transition-colors ${
+                                    activePreset === preset.key
+                                        ? 'border-mm-accent-primary bg-mm-accent-primary/10 text-mm-accent-primary'
+                                        : 'border-mm-border bg-mm-surface-subtle text-mm-text-secondary hover:text-mm-text-primary'
+                                }`}
+                                onClick={() => handlePresetChange(preset.key)}
+                            >
+                                {preset.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div className="ui-panel p-4 mb-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-3">
+                    <input
+                        className="ui-input"
+                        placeholder="Search symbol or company"
+                        value={draftFilters.query}
+                        onChange={(event) => setDraftFilters((current) => ({ ...current, query: event.target.value }))}
+                    />
+                    <input
+                        className="ui-input"
+                        inputMode="decimal"
+                        placeholder="Min price"
+                        value={draftFilters.priceMin}
+                        onChange={(event) => setDraftFilters((current) => ({ ...current, priceMin: event.target.value }))}
+                    />
+                    <input
+                        className="ui-input"
+                        inputMode="decimal"
+                        placeholder="Max price"
+                        value={draftFilters.priceMax}
+                        onChange={(event) => setDraftFilters((current) => ({ ...current, priceMax: event.target.value }))}
+                    />
+                    <input
+                        className="ui-input"
+                        inputMode="decimal"
+                        placeholder="Min market cap"
+                        value={draftFilters.marketCapMin}
+                        onChange={(event) => setDraftFilters((current) => ({ ...current, marketCapMin: event.target.value }))}
+                    />
+                    <input
+                        className="ui-input"
+                        inputMode="decimal"
+                        placeholder="Min avg $ volume"
+                        value={draftFilters.avgDollarVolumeMin}
+                        onChange={(event) => setDraftFilters((current) => ({ ...current, avgDollarVolumeMin: event.target.value }))}
+                    />
+                    <select
+                        className="ui-input"
+                        value={draftFilters.sector}
+                        onChange={(event) => setDraftFilters((current) => ({ ...current, sector: event.target.value }))}
+                    >
+                        <option value="">All sectors</option>
+                        {sectors.map((sector) => (
+                            <option key={sector} value={sector}>
+                                {sector}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="flex items-center gap-2 mt-3">
+                    <button type="button" className="ui-button-primary" onClick={applyFilters}>
+                        Apply Filters
+                    </button>
+                    <button type="button" className="ui-button-secondary" onClick={clearFilters}>
+                        Clear
+                    </button>
+                </div>
+            </div>
+
+            {meta?.snapshotStatus === 'stale' && (
+                <div className="ui-banner ui-banner-warning mb-4">
+                    Showing the last good screener snapshot while fresh data reloads.
+                </div>
+            )}
+
+            {meta?.lastRefresh && (
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-4 text-sm text-mm-text-secondary">
+                    <span>
+                        {presetMap[activePreset]?.description || 'Liquid U.S. equity discovery view.'}
+                    </span>
+                    <span>
+                        Last refresh: {formatDateTime(meta.lastRefresh)}
+                    </span>
+                </div>
+            )}
+
             <div className="ui-panel overflow-hidden">
                 {loading && (
                     <div className="p-12 text-center">
                         <div className="inline-block animate-spin rounded-full h-10 w-10 border-4 border-mm-accent-primary border-t-transparent mb-3"></div>
-                        <p className="text-mm-text-secondary">Loading market data…</p>
+                        <p className="text-mm-text-secondary">Loading screener snapshot…</p>
                     </div>
                 )}
                 {error && !loading && (
@@ -108,43 +361,49 @@ const ScreenerPage = ({ onSearchTicker }) => {
                         <table className="min-w-full text-sm">
                             <thead className="bg-mm-surface-subtle border-b border-mm-border">
                                 <tr>
-                                    <th className="px-4 py-3 text-left text-xs font-semibold text-mm-text-secondary uppercase tracking-wider">Symbol</th>
-                                    <SortTh label="Price"    sortKey="price"          />
-                                    <SortTh label="Change %"  sortKey="percent_change" />
-                                    <SortTh label="Mkt Cap"  sortKey="market_cap"     />
-                                    <SortTh label="Volume"   sortKey="volume"         />
-                                    <SortTh label="P/E Fwd"  sortKey="pe_forward"     />
-                                    <SortTh label="52W High" sortKey="year_high"      />
-                                    <SortTh label="52W Low"  sortKey="year_low"       />
+                                    <SortTh label="Symbol" sortKey="symbol" />
+                                    {columns.slice(1).map((column) => (
+                                        <SortTh key={column.key} label={column.label} sortKey={column.key} />
+                                    ))}
+                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-mm-text-secondary">Sector</th>
                                     <th className="px-4 py-3"></th>
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-mm-border">
                                 {rows.map((stock) => {
-                                    const pos = (stock.percent_change ?? 0) >= 0;
+                                    const positiveMove = Number(stock.percent_change || 0) >= 0;
                                     return (
                                         <tr
-                                            key={stock.symbol}
+                                            key={`${stock.symbol}-${stock.index_membership || ''}`}
                                             className="hover:bg-mm-surface-subtle transition-colors cursor-pointer group"
                                             onClick={() => onSearchTicker && onSearchTicker(stock.symbol)}
                                         >
                                             <td className="px-4 py-3">
                                                 <div className="font-semibold text-mm-text-primary">{stock.symbol}</div>
-                                                <div className="text-xs text-mm-text-secondary truncate max-w-[160px]">{stock.name}</div>
+                                                <div className="text-xs text-mm-text-secondary truncate max-w-[180px]">{stock.name}</div>
                                             </td>
                                             <td className="px-4 py-3 font-medium text-mm-text-primary">
-                                                ${fmt(stock.price)}
+                                                {stock.price !== null && stock.price !== undefined ? `$${Number(stock.price).toFixed(2)}` : '—'}
                                             </td>
-                                            <td className={`px-4 py-3 font-semibold ${pos ? 'text-mm-positive' : 'text-mm-negative'}`}>
-                                                {pos ? '+' : ''}{stock.percent_change !== null ? (stock.percent_change * 100).toFixed(2) : '—'}%
+                                            <td className={`px-4 py-3 font-semibold ${positiveMove ? 'text-mm-positive' : 'text-mm-negative'}`}>
+                                                {positiveMove ? '+' : ''}{formatPercent(stock.percent_change, 100)}
                                             </td>
-                                            <td className="px-4 py-3 text-mm-text-secondary">{fmt(stock.market_cap, '$')}</td>
-                                            <td className="px-4 py-3 text-mm-text-secondary">{fmt(stock.volume)}</td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">{formatCompactNumber(stock.market_cap, '$')}</td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">{formatCompactNumber(stock.avg_dollar_volume_30d, '$')}</td>
                                             <td className="px-4 py-3 text-mm-text-secondary">
-                                                {stock.pe_forward !== null ? stock.pe_forward.toFixed(1) : '—'}
+                                                {stock.relative_volume_20d !== null && stock.relative_volume_20d !== undefined ? Number(stock.relative_volume_20d).toFixed(2) : '—'}
                                             </td>
-                                            <td className="px-4 py-3 text-mm-text-secondary">${fmt(stock.year_high)}</td>
-                                            <td className="px-4 py-3 text-mm-text-secondary">${fmt(stock.year_low)}</td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">{formatPercent(stock.momentum_3m, 100)}</td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">
+                                                {stock.pe_forward !== null && stock.pe_forward !== undefined ? Number(stock.pe_forward).toFixed(1) : '—'}
+                                            </td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">
+                                                {stock.year_high !== null && stock.year_high !== undefined ? `$${Number(stock.year_high).toFixed(2)}` : '—'}
+                                            </td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">
+                                                {stock.year_low !== null && stock.year_low !== undefined ? `$${Number(stock.year_low).toFixed(2)}` : '—'}
+                                            </td>
+                                            <td className="px-4 py-3 text-mm-text-secondary">{stock.sector || '—'}</td>
                                             <td className="px-4 py-3">
                                                 <ExternalLink className="w-4 h-4 text-mm-accent-primary opacity-0 group-hover:opacity-100" />
                                             </td>
@@ -153,15 +412,48 @@ const ScreenerPage = ({ onSearchTicker }) => {
                                 })}
                             </tbody>
                         </table>
+
                         {rows.length === 0 && (
-                            <p className="py-8 text-center text-mm-text-secondary">No data available.</p>
+                            <p className="py-8 text-center text-mm-text-secondary">No screener matches found for the current filters.</p>
                         )}
                     </div>
                 )}
             </div>
-            <p className="mt-3 text-xs text-mm-text-tertiary">
-                Data via Yahoo Finance · Click any row to open in Search
-            </p>
+
+            {!loading && !error && (
+                <div className="flex flex-wrap items-center justify-between gap-3 mt-4 text-sm text-mm-text-secondary">
+                    <span>
+                        Showing {rows.length ? offset + 1 : 0}-{Math.min(offset + rows.length, total)} of {total.toLocaleString()}
+                    </span>
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            className="ui-button-secondary flex items-center gap-1"
+                            disabled={offset === 0}
+                            onClick={() => setOffset((current) => Math.max(0, current - DEFAULT_SCAN_LIMIT))}
+                        >
+                            <ChevronLeft className="w-4 h-4" />
+                            Prev
+                        </button>
+                        <span>Page {currentPage} / {totalPages}</span>
+                        <button
+                            type="button"
+                            className="ui-button-secondary flex items-center gap-1"
+                            disabled={offset + DEFAULT_SCAN_LIMIT >= total}
+                            onClick={() => setOffset((current) => current + DEFAULT_SCAN_LIMIT)}
+                        >
+                            Next
+                            <ChevronRight className="w-4 h-4" />
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {Array.isArray(meta?.warnings) && meta.warnings.length > 0 && (
+                <div className="mt-3 text-xs text-mm-text-tertiary">
+                    {meta.warnings[0]}
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/components/ScreenerPage.test.js
+++ b/frontend/src/components/ScreenerPage.test.js
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ScreenerPage from './ScreenerPage';
+import { API_ENDPOINTS, apiRequest } from '../config/api';
+
+jest.mock('../config/api', () => {
+    const actual = jest.requireActual('../config/api');
+    return {
+        ...actual,
+        apiRequest: jest.fn(),
+    };
+});
+
+const presetsPayload = {
+    presets: [
+        { key: 'gainers', label: 'Top Gainers', description: 'Daily movers', defaultSort: 'percent_change', defaultDir: 'desc' },
+        { key: 'losers', label: 'Top Losers', description: 'Daily decliners', defaultSort: 'percent_change', defaultDir: 'asc' },
+        { key: 'active', label: 'Most Active', description: 'Relative volume leaders', defaultSort: 'relative_volume_20d', defaultDir: 'desc' },
+        { key: 'momentum_leaders', label: 'Momentum Leaders', description: 'Positive 3M trend', defaultSort: 'momentum_3m', defaultDir: 'desc' },
+    ],
+    sectors: ['Technology', 'Financials'],
+};
+
+const gainersPayload = {
+    rows: [
+        {
+            symbol: 'AAPL',
+            name: 'Apple Inc.',
+            price: 210.5,
+            percent_change: 0.021,
+            market_cap: 3100000000000,
+            avg_dollar_volume_30d: 9500000000,
+            relative_volume_20d: 1.18,
+            momentum_3m: 0.12,
+            pe_forward: 28.1,
+            year_high: 220.0,
+            year_low: 165.0,
+            sector: 'Technology',
+        },
+    ],
+    meta: {
+        total: 1,
+        limit: 25,
+        offset: 0,
+        lastRefresh: '2026-04-03T13:00:00+00:00',
+        snapshotStatus: 'fresh',
+        warnings: [],
+    },
+    filters: {
+        availableSectors: ['Technology', 'Financials'],
+    },
+};
+
+const momentumPayload = {
+    rows: [
+        {
+            symbol: 'MSFT',
+            name: 'Microsoft Corporation',
+            price: 425.2,
+            percent_change: 0.014,
+            market_cap: 3200000000000,
+            avg_dollar_volume_30d: 8700000000,
+            relative_volume_20d: 1.09,
+            momentum_3m: 0.16,
+            pe_forward: 31.4,
+            year_high: 430.0,
+            year_low: 330.0,
+            sector: 'Technology',
+        },
+    ],
+    meta: {
+        total: 1,
+        limit: 25,
+        offset: 0,
+        lastRefresh: '2026-04-03T13:00:00+00:00',
+        snapshotStatus: 'stale',
+        warnings: ['Showing the last good screener snapshot while fresh data reloads.'],
+    },
+    filters: {
+        availableSectors: ['Technology', 'Financials'],
+    },
+};
+
+describe('ScreenerPage', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('renders presets, scan results, and routes row clicks into Search', async () => {
+        const onSearchTicker = jest.fn();
+        apiRequest.mockImplementation((url) => {
+            if (url === API_ENDPOINTS.SCREENER_PRESETS) {
+                return Promise.resolve(presetsPayload);
+            }
+            if (url.includes('/screener/scan?preset=gainers')) {
+                return Promise.resolve(gainersPayload);
+            }
+            if (url.includes('/screener/scan?preset=momentum_leaders')) {
+                return Promise.resolve(momentumPayload);
+            }
+            throw new Error(`Unhandled request: ${url}`);
+        });
+
+        render(<ScreenerPage onSearchTicker={onSearchTicker} />);
+
+        expect(await screen.findByText('Apple Inc.')).toBeInTheDocument();
+        expect(screen.getByText('Momentum Leaders')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Apple Inc.'));
+        expect(onSearchTicker).toHaveBeenCalledWith('AAPL');
+
+        fireEvent.click(screen.getByText('Momentum Leaders'));
+
+        expect(await screen.findByText('Microsoft Corporation')).toBeInTheDocument();
+        expect(screen.getAllByText('Showing the last good screener snapshot while fresh data reloads.').length).toBeGreaterThan(0);
+    });
+
+    test('applies screener filters through the scan endpoint', async () => {
+        apiRequest.mockImplementation((url) => {
+            if (url === API_ENDPOINTS.SCREENER_PRESETS) {
+                return Promise.resolve(presetsPayload);
+            }
+            if (url.includes('/screener/scan?preset=gainers')) {
+                return Promise.resolve(gainersPayload);
+            }
+            throw new Error(`Unhandled request: ${url}`);
+        });
+
+        render(<ScreenerPage />);
+
+        await screen.findByText('Apple Inc.');
+
+        fireEvent.change(screen.getByPlaceholderText('Min market cap'), { target: { value: '1000000000' } });
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Technology' } });
+        fireEvent.click(screen.getByText('Apply Filters'));
+
+        await waitFor(() => {
+            expect(apiRequest).toHaveBeenCalledWith(
+                expect.stringContaining('market_cap_min=1000000000'),
+            );
+        });
+        expect(apiRequest).toHaveBeenCalledWith(expect.stringContaining('sector=Technology'));
+    });
+});

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -152,6 +152,8 @@ export const API_ENDPOINTS = {
     
     // Screener
     SCREENER: (category = 'day_gainers') => `${API_BASE_URL}/screener?category=${category}`,
+    SCREENER_PRESETS: `${API_BASE_URL}/screener/presets`,
+    SCREENER_SCAN: (params = {}) => buildApiUrl('/screener/scan', params),
     
     // Fundamentals
     FUNDAMENTALS: (ticker, market = 'us') =>

--- a/frontend/src/config/api.test.js
+++ b/frontend/src/config/api.test.js
@@ -105,4 +105,19 @@ describe('API_ENDPOINTS', () => {
             `${API_BASE_URL}/paper/portfolio/optimize`
         );
     });
+
+    test('builds screener preset and scan URLs', () => {
+        expect(API_ENDPOINTS.SCREENER_PRESETS).toBe(
+            `${API_BASE_URL}/screener/presets`
+        );
+        expect(API_ENDPOINTS.SCREENER_SCAN({
+            preset: 'momentum_leaders',
+            sector: 'Technology',
+            limit: 25,
+            sort: 'momentum_3m',
+            dir: 'desc',
+        })).toBe(
+            `${API_BASE_URL}/screener/scan?preset=momentum_leaders&sector=Technology&limit=25&sort=momentum_3m&dir=desc`
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- upgrade the Screener page with preset chips, filters, pagination, and freshness states
- keep Search compatibility on the legacy /screener mover buckets
- add focused frontend tests for the new screener flow

## Planned cadence
- Target publish window: Friday, April 10, 2026
- This PR is intentionally draft until PR #116 is merged in the rollout sequence

## Stacked On
- #116
