### PR TITLE
Make Screener the front door of MarketMind

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,9 +41,11 @@ function App() {
     const { isLoaded, isSignedIn } = useAuth();
     const { user } = useUser();
     const [showLanding, setShowLanding] = useState(() => !shouldHideLandingByDefault());
-    const [activePage, setActivePage] = useState('dashboard');
+    const [activePage, setActivePage] = useState('screener');
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
     const [sharedTicker, setSharedTicker] = useState(null);
+    const [sharedCompareTicker, setSharedCompareTicker] = useState(null);
+    const [sharedAiPrompt, setSharedAiPrompt] = useState('');
     const [checkoutAnnual, setCheckoutAnnual] = useState(false);
     const [subscriptionNotice, setSubscriptionNotice] = useState(null);
     useEffect(() => {
@@ -76,6 +78,42 @@ function App() {
 
     const handleScreenerNav = (ticker) => {
         setSharedTicker(ticker);
+        setSharedCompareTicker(null);
+        setActivePage('search');
+    };
+
+    const handleScreenerAction = ({ action, ticker, compareTicker }) => {
+        const normalizedTicker = String(ticker || '').trim().toUpperCase();
+        const normalizedCompareTicker = String(compareTicker || '').trim().toUpperCase();
+        if (!normalizedTicker) return;
+
+        setSharedTicker(normalizedTicker);
+        setSharedCompareTicker(null);
+        setSharedAiPrompt('');
+
+        if (action === 'predictions') {
+            setActivePage('predictions');
+            return;
+        }
+        if (action === 'fundamentals') {
+            setActivePage('fundamentals');
+            return;
+        }
+        if (action === 'paper') {
+            setActivePage('portfolio');
+            return;
+        }
+        if (action === 'ai') {
+            setSharedAiPrompt(`Analyze ${normalizedTicker} from the Screener. Summarize why it surfaced, what to validate next, and what risks to check before acting.`);
+            setActivePage('marketmindAI');
+            return;
+        }
+        if (action === 'compare' && normalizedCompareTicker) {
+            setSharedCompareTicker(normalizedCompareTicker);
+            setActivePage('search');
+            return;
+        }
+
         setActivePage('search');
     };
 
@@ -154,8 +192,22 @@ function App() {
                             </div>
                         )}
                         {activePage === 'dashboard' && <DashboardPage setActivePage={setActivePage} />}
-                        {activePage === 'search' && <SearchPage initialTicker={sharedTicker} onClearInitialTicker={() => setSharedTicker(null)} />}
-                        {activePage === 'screener' && <ScreenerPage onSearchTicker={handleScreenerNav} />}
+                        {activePage === 'search' && (
+                            <SearchPage
+                                initialTicker={sharedTicker}
+                                initialCompareTicker={sharedCompareTicker}
+                                onClearInitialTicker={() => {
+                                    setSharedTicker(null);
+                                    setSharedCompareTicker(null);
+                                }}
+                            />
+                        )}
+                        {activePage === 'screener' && (
+                            <ScreenerPage
+                                onSearchTicker={handleScreenerNav}
+                                onScreenerAction={handleScreenerAction}
+                            />
+                        )}
                         {activePage === 'plan' && (
                             <PlanPage
                                 onNavigateToCheckout={(isAnnual) => {
@@ -174,9 +226,24 @@ function App() {
                         )}
                         {activePage === 'macro' && <MacroPage />}
                         {activePage === 'watchlist' && <WatchlistPage />}
-                        {activePage === 'portfolio' && <PaperTradingPage />}
-                        {activePage === 'fundamentals' && <FundamentalsPage />}
-                        {activePage === 'predictions' && <PredictionsPage />}
+                        {activePage === 'portfolio' && (
+                            <PaperTradingPage
+                                initialTicker={sharedTicker}
+                                onConsumeInitialTicker={() => setSharedTicker(null)}
+                            />
+                        )}
+                        {activePage === 'fundamentals' && (
+                            <FundamentalsPage
+                                initialTicker={sharedTicker}
+                                onConsumeInitialTicker={() => setSharedTicker(null)}
+                            />
+                        )}
+                        {activePage === 'predictions' && (
+                            <PredictionsPage
+                                initialTicker={sharedTicker}
+                                onConsumeInitialTicker={() => setSharedTicker(null)}
+                            />
+                        )}
                         {activePage === 'performance' && <ModelPerformancePage />}
                         {activePage === 'options' && <OptionsPage />}
                         {activePage === 'forex' && <ForexPage />}
@@ -185,7 +252,12 @@ function App() {
                         {activePage === 'news' && <NewsPage />}
                         {activePage === 'notifications' && <NotificationsPage />}
                         {activePage === 'predictionMarkets' && <PredictionMarketsPage />}
-                        {activePage === 'marketmindAI' && <MarketMindAIPage />}
+                        {activePage === 'marketmindAI' && (
+                            <MarketMindAIPage
+                                initialPrompt={sharedAiPrompt}
+                                onConsumeInitialPrompt={() => setSharedAiPrompt('')}
+                            />
+                        )}
                         {activePage === 'gettingStarted' && <GettingStartedPage />}
                         {activePage === 'calendar' && <MarketCalendarPage />}
                     </main>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -97,12 +97,12 @@ describe('App', () => {
         expect(screen.getByTestId('auth-fetch-bridge')).toBeInTheDocument();
     });
 
-    test('shows the signed-in shell after entering the app when signed in', () => {
+    test('shows the signed-in shell on the screener front door when signed in', () => {
         mockIsSignedIn = true;
         render(<App />);
 
         expect(screen.getByText('Sidebar')).toBeInTheDocument();
-        expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+        expect(screen.getByText('Screener Page')).toBeInTheDocument();
     });
 
     test('routes screener selections into the search page ticker state', () => {
@@ -122,7 +122,7 @@ describe('App', () => {
 
         expect(screen.queryByText('Landing Page')).not.toBeInTheDocument();
         expect(screen.getByText('Sidebar')).toBeInTheDocument();
-        expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+        expect(screen.getByText('Screener Page')).toBeInTheDocument();
     });
 
     test('persists app entry so refresh stays in the app shell', () => {

--- a/frontend/src/components/DashboardPage.js
+++ b/frontend/src/components/DashboardPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
-    Search, Star, Briefcase, Building2, TrendingUp, Target,
+    Search, Star, Briefcase, Building2, TrendingUp, Target, SlidersHorizontal,
     DollarSign, Newspaper, Bell, ArrowUpRight, ArrowDownRight
 } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
@@ -14,6 +14,7 @@ const MARKET_TICKERS = [
 ];
 
 const QUICK_ACCESS = [
+    { page: 'screener', icon: SlidersHorizontal, label: 'Screener' },
     { page: 'search', icon: Search, label: 'Search' },
     { page: 'watchlist', icon: Star, label: 'Watchlist' },
     { page: 'portfolio', icon: Briefcase, label: 'Portfolio' },

--- a/frontend/src/components/FundamentalsPage.js
+++ b/frontend/src/components/FundamentalsPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     Building2,
     Search,
@@ -266,7 +266,7 @@ const AnnouncementsPanel = ({ items }) => {
     );
 };
 
-const FundamentalsPage = () => {
+const FundamentalsPage = ({ initialTicker, onConsumeInitialTicker }) => {
     const [ticker, setTicker] = useState('');
     const [selectedMarket, setSelectedMarket] = useState('us');
     const [resolvedAsset, setResolvedAsset] = useState(null);
@@ -286,11 +286,10 @@ const FundamentalsPage = () => {
     const tabs = internationalResearchMode ? INTERNATIONAL_TABS : US_TABS;
     const marketSession = fundamentals?.marketSession || null;
 
-    const handleSearch = async (e) => {
-        e.preventDefault();
-        if (!ticker.trim()) return;
+    const loadFundamentals = async (rawTicker, marketOverride = selectedMarket) => {
+        if (!String(rawTicker || '').trim()) return;
 
-        const asset = normalizeAssetInput(ticker, selectedMarket);
+        const asset = normalizeAssetInput(rawTicker, marketOverride);
         if (!asset) {
             setError('Enter a valid ticker like AAPL, HK:00700, or CN:600519.');
             return;
@@ -344,6 +343,18 @@ const FundamentalsPage = () => {
             setLoading(false);
         }
     };
+
+    const handleSearch = async (e) => {
+        e.preventDefault();
+        await loadFundamentals(ticker, selectedMarket);
+    };
+
+    useEffect(() => {
+        if (!initialTicker) return;
+        loadFundamentals(initialTicker, 'us');
+        if (onConsumeInitialTicker) onConsumeInitialTicker();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initialTicker]);
 
     const formatNumber = (value, prefix = '', suffix = '') => {
         if (value === 'N/A' || value === 'None' || value === null || value === undefined || value === '') return 'N/A';

--- a/frontend/src/components/MarketMindAIPage.js
+++ b/frontend/src/components/MarketMindAIPage.js
@@ -283,7 +283,7 @@ const ArtifactPreview = ({ artifact, version }) => {
     );
 };
 
-const MarketMindAIPage = () => {
+const MarketMindAIPage = ({ initialPrompt, onConsumeInitialPrompt }) => {
     const { isLoaded, isSignedIn } = useAuth();
     const [bootstrap, setBootstrap] = useState({ starterPrompts: [], templates: [] });
     const [activeChatId, setActiveChatId] = useState(null);
@@ -427,6 +427,13 @@ const MarketMindAIPage = () => {
         }
         loadBootstrap();
     }, [isLoaded, isSignedIn]);
+
+    useEffect(() => {
+        const nextPrompt = String(initialPrompt || '').trim();
+        if (!nextPrompt) return;
+        setComposerValue(nextPrompt);
+        if (onConsumeInitialPrompt) onConsumeInitialPrompt();
+    }, [initialPrompt, onConsumeInitialPrompt]);
 
     const handleExternalChatSelection = useEffectEvent((chatId) => {
         if (chatId) {

--- a/frontend/src/components/PaperTradingPage.js
+++ b/frontend/src/components/PaperTradingPage.js
@@ -384,7 +384,7 @@ const holdingsEmptyClass = 'ui-panel-subtle border-dashed py-20 text-center';
 const positionCardClass = 'ui-panel p-6 transition-all';
 
 // --- MAIN APPLICATION COMPONENT ---
-export default function App() {
+export default function App({ initialTicker, onConsumeInitialTicker }) {
     const [portfolio, setPortfolio] = useState(null);
     const [stockPositions, setStockPositions] = useState([]);
     const [optionsPositions, setOptionsPositions] = useState([]);
@@ -406,6 +406,15 @@ export default function App() {
     const [optimizationData, setOptimizationData] = useState(null);
     const [optimizationLoading, setOptimizationLoading] = useState(false);
     const [optimizationError, setOptimizationError] = useState('');
+
+    useEffect(() => {
+        const normalizedTicker = String(initialTicker || '').trim().toUpperCase();
+        if (!normalizedTicker) return;
+        setBuyTicker(normalizedTicker);
+        setBuyShares('');
+        setShowBuyModal(true);
+        if (onConsumeInitialTicker) onConsumeInitialTicker();
+    }, [initialTicker, onConsumeInitialTicker]);
 
     const fetchPortfolio = async (isManualRefresh = false) => {
         if (isManualRefresh) setRefreshing(true);

--- a/frontend/src/components/PredictionsPage.js
+++ b/frontend/src/components/PredictionsPage.js
@@ -6,7 +6,7 @@ import { API_ENDPOINTS, apiRequest } from '../config/api';
 
 const DEFAULT_SINGLE_MODEL = 'LinReg';
 
-const PredictionsPage = ({ initialTicker }) => {
+const PredictionsPage = ({ initialTicker, onConsumeInitialTicker }) => {
     const [ticker, setTicker] = useState('');
     const [predictionData, setPredictionData] = useState(null);
     const [loading, setLoading] = useState(false);
@@ -25,6 +25,7 @@ const PredictionsPage = ({ initialTicker }) => {
         if (initialTicker && initialTicker.trim()) {
             setTicker(initialTicker);
             fetchPredictions(initialTicker);
+            if (onConsumeInitialTicker) onConsumeInitialTicker();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialTicker, useEnsemble]);

--- a/frontend/src/components/ScreenerPage.js
+++ b/frontend/src/components/ScreenerPage.js
@@ -314,7 +314,7 @@ const ScreenerPage = ({ onSearchTicker, onScreenerAction }) => {
 
             {actionNotice && (
                 <div
-                    className={`mb-4 rounded-card border px-4 py-3 text-sm ${
+                    className={`mb-4 flex items-center justify-between gap-3 rounded-card border px-4 py-3 text-sm ${
                         actionNotice.type === 'error'
                             ? 'border-mm-negative/20 bg-mm-negative/10 text-mm-negative'
                             : actionNotice.type === 'success'
@@ -322,7 +322,14 @@ const ScreenerPage = ({ onSearchTicker, onScreenerAction }) => {
                                 : 'border-mm-accent-primary/20 bg-mm-accent-primary/10 text-mm-accent-primary'
                     }`}
                 >
-                    {actionNotice.text}
+                    <span>{actionNotice.text}</span>
+                    <button
+                        type="button"
+                        onClick={() => setActionNotice(null)}
+                        className="text-xs font-semibold opacity-70 transition hover:opacity-100"
+                    >
+                        Dismiss
+                    </button>
                 </div>
             )}
 
@@ -502,28 +509,32 @@ const ScreenerPage = ({ onSearchTicker, onScreenerAction }) => {
                                             </td>
                                             <td className="px-4 py-3 text-mm-text-secondary">{stock.sector || '—'}</td>
                                             <td className="px-4 py-3">
-                                                <div className="flex min-w-[360px] flex-wrap gap-1.5">
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'search', stock)}>
+                                                <div className="flex min-w-[420px] flex-wrap items-center gap-2">
+                                                    <button type="button" className="ui-button-primary px-3 py-1.5 text-xs" onClick={(event) => handleAction(event, 'search', stock)}>
                                                         Open
                                                     </button>
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'predictions', stock)}>
-                                                        Predict
-                                                    </button>
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'fundamentals', stock)}>
-                                                        Fundamentals
-                                                    </button>
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'ai', stock)}>
-                                                        Ask AI
-                                                    </button>
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAddToWatchlist(event, stock)}>
-                                                        Watchlist
-                                                    </button>
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'paper', stock)}>
-                                                        Paper Trade
-                                                    </button>
-                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'compare', stock)}>
-                                                        Compare
-                                                    </button>
+                                                    <div className="flex flex-wrap gap-1.5">
+                                                        <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'predictions', stock)}>
+                                                            Predict
+                                                        </button>
+                                                        <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'fundamentals', stock)}>
+                                                            Fundamentals
+                                                        </button>
+                                                        <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'ai', stock)}>
+                                                            Ask AI
+                                                        </button>
+                                                    </div>
+                                                    <div className="flex flex-wrap gap-1.5 border-l border-mm-border pl-2">
+                                                        <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAddToWatchlist(event, stock)}>
+                                                            Watchlist
+                                                        </button>
+                                                        <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'paper', stock)}>
+                                                            Paper Trade
+                                                        </button>
+                                                        <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'compare', stock)}>
+                                                            Compare
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </td>
                                         </tr>

--- a/frontend/src/components/ScreenerPage.js
+++ b/frontend/src/components/ScreenerPage.js
@@ -4,7 +4,6 @@ import {
     ArrowUpDown,
     ChevronLeft,
     ChevronRight,
-    ExternalLink,
     RefreshCw,
     SlidersHorizontal,
     TrendingDown,
@@ -71,7 +70,7 @@ const columns = [
     { key: 'year_low', label: '52W Low', formatter: (value) => (value === null || value === undefined ? '—' : `$${Number(value).toFixed(2)}`) },
 ];
 
-const ScreenerPage = ({ onSearchTicker }) => {
+const ScreenerPage = ({ onSearchTicker, onScreenerAction }) => {
     const [presets, setPresets] = useState([]);
     const [sectors, setSectors] = useState([]);
     const [activePreset, setActivePreset] = useState('gainers');
@@ -83,6 +82,8 @@ const ScreenerPage = ({ onSearchTicker }) => {
     const [draftFilters, setDraftFilters] = useState(blankFilters);
     const [appliedFilters, setAppliedFilters] = useState(blankFilters);
     const [offset, setOffset] = useState(0);
+    const [compareAnchor, setCompareAnchor] = useState(null);
+    const [actionNotice, setActionNotice] = useState(null);
 
     useEffect(() => {
         let cancelled = false;
@@ -191,6 +192,55 @@ const ScreenerPage = ({ onSearchTicker }) => {
         }));
     };
 
+    const rowReason = (stock) => {
+        if (activePreset === 'active') {
+            return `${stock.relative_volume_20d ? `${Number(stock.relative_volume_20d).toFixed(2)}x` : 'Elevated'} relative volume`;
+        }
+        if (activePreset === 'momentum_leaders') {
+            return `${formatPercent(stock.momentum_3m, 100)} 3M momentum near highs`;
+        }
+        if (activePreset === 'near_highs') {
+            return `${formatPercent(stock.distance_from_52w_high_pct, 1)} from 52W high`;
+        }
+        if (activePreset === 'oversold_rebounds') {
+            return `Rebounding ${formatPercent(stock.distance_from_52w_low_pct, 1)} from 52W low`;
+        }
+        return `${Number(stock.percent_change || 0) >= 0 ? '+' : ''}${formatPercent(stock.percent_change, 100)} daily move`;
+    };
+
+    const handleAction = (event, action, stock) => {
+        event.stopPropagation();
+        if (action === 'search') {
+            onSearchTicker && onSearchTicker(stock.symbol);
+            return;
+        }
+        if (action === 'compare') {
+            if (!compareAnchor || compareAnchor.symbol === stock.symbol) {
+                setCompareAnchor({ symbol: stock.symbol, name: stock.name });
+                setActionNotice({ type: 'info', text: `${stock.symbol} set as compare base. Pick another row to compare.` });
+                return;
+            }
+            onScreenerAction && onScreenerAction({
+                action: 'compare',
+                ticker: compareAnchor.symbol,
+                compareTicker: stock.symbol,
+                stock,
+            });
+            return;
+        }
+        onScreenerAction && onScreenerAction({ action, ticker: stock.symbol, stock });
+    };
+
+    const handleAddToWatchlist = async (event, stock) => {
+        event.stopPropagation();
+        try {
+            const result = await apiRequest(API_ENDPOINTS.WATCHLIST_ITEM(stock.symbol), { method: 'POST' });
+            setActionNotice({ type: 'success', text: result?.message || `${stock.symbol} added to watchlist.` });
+        } catch (requestError) {
+            setActionNotice({ type: 'error', text: requestError?.message || `Could not add ${stock.symbol} to watchlist.` });
+        }
+    };
+
     const SortTh = ({ label, sortKey, className = '' }) => {
         const active = sortConfig.key === sortKey;
         return (
@@ -209,13 +259,45 @@ const ScreenerPage = ({ onSearchTicker }) => {
     return (
         <div className="ui-page animate-fade-in">
             <div className="ui-page-header">
-                <div className="flex items-start justify-between gap-4">
+                <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
                     <div>
+                        <p className="ui-section-label mb-2">Find → validate → act</p>
                         <h1 className="ui-page-title">Stock Screener</h1>
                         <p className="ui-page-subtitle mt-1">
-                            Internal U.S. equity discovery with cached market movers, momentum, and liquidity screens.
+                            Start with liquid U.S. equity ideas, then jump directly into analysis, AI, watchlist, or paper trading.
                         </p>
                     </div>
+                    <div className="grid gap-2 text-sm sm:grid-cols-3 lg:min-w-[520px]">
+                        {['Find setups', 'Validate context', 'Act quickly'].map((label, index) => (
+                            <div key={label} className="ui-panel-subtle p-3">
+                                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-mm-text-tertiary">Step {index + 1}</p>
+                                <p className="mt-1 font-semibold text-mm-text-primary">{label}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                <div className="text-sm text-mm-text-secondary">
+                    {compareAnchor ? (
+                        <span>
+                            Compare base: <strong className="text-mm-text-primary">{compareAnchor.symbol}</strong>. Choose another row.
+                        </span>
+                    ) : (
+                        <span>Rows are gateways: open, validate, ask AI, track, trade, or compare.</span>
+                    )}
+                </div>
+                <div className="flex items-center gap-2">
+                    {compareAnchor && (
+                        <button
+                            type="button"
+                            className="ui-button-secondary"
+                            onClick={() => setCompareAnchor(null)}
+                        >
+                            Clear Compare
+                        </button>
+                    )}
                     <button
                         type="button"
                         className="ui-button-secondary flex items-center gap-2"
@@ -229,6 +311,20 @@ const ScreenerPage = ({ onSearchTicker }) => {
                     </button>
                 </div>
             </div>
+
+            {actionNotice && (
+                <div
+                    className={`mb-4 rounded-card border px-4 py-3 text-sm ${
+                        actionNotice.type === 'error'
+                            ? 'border-mm-negative/20 bg-mm-negative/10 text-mm-negative'
+                            : actionNotice.type === 'success'
+                                ? 'border-mm-positive/20 bg-mm-positive/10 text-mm-positive'
+                                : 'border-mm-accent-primary/20 bg-mm-accent-primary/10 text-mm-accent-primary'
+                    }`}
+                >
+                    {actionNotice.text}
+                </div>
+            )}
 
             <div className="flex flex-wrap gap-2 mb-4">
                 {PRIMARY_PRESETS.map(({ key, label, icon: Icon, color }) => (
@@ -366,7 +462,7 @@ const ScreenerPage = ({ onSearchTicker }) => {
                                         <SortTh key={column.key} label={column.label} sortKey={column.key} />
                                     ))}
                                     <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-mm-text-secondary">Sector</th>
-                                    <th className="px-4 py-3"></th>
+                                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-mm-text-secondary">Actions</th>
                                 </tr>
                             </thead>
                             <tbody className="divide-y divide-mm-border">
@@ -381,6 +477,7 @@ const ScreenerPage = ({ onSearchTicker }) => {
                                             <td className="px-4 py-3">
                                                 <div className="font-semibold text-mm-text-primary">{stock.symbol}</div>
                                                 <div className="text-xs text-mm-text-secondary truncate max-w-[180px]">{stock.name}</div>
+                                                <div className="mt-1 text-[11px] font-medium text-mm-accent-primary">{rowReason(stock)}</div>
                                             </td>
                                             <td className="px-4 py-3 font-medium text-mm-text-primary">
                                                 {stock.price !== null && stock.price !== undefined ? `$${Number(stock.price).toFixed(2)}` : '—'}
@@ -405,7 +502,29 @@ const ScreenerPage = ({ onSearchTicker }) => {
                                             </td>
                                             <td className="px-4 py-3 text-mm-text-secondary">{stock.sector || '—'}</td>
                                             <td className="px-4 py-3">
-                                                <ExternalLink className="w-4 h-4 text-mm-accent-primary opacity-0 group-hover:opacity-100" />
+                                                <div className="flex min-w-[360px] flex-wrap gap-1.5">
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'search', stock)}>
+                                                        Open
+                                                    </button>
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'predictions', stock)}>
+                                                        Predict
+                                                    </button>
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'fundamentals', stock)}>
+                                                        Fundamentals
+                                                    </button>
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'ai', stock)}>
+                                                        Ask AI
+                                                    </button>
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAddToWatchlist(event, stock)}>
+                                                        Watchlist
+                                                    </button>
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'paper', stock)}>
+                                                        Paper Trade
+                                                    </button>
+                                                    <button type="button" className="ui-button-secondary px-2 py-1 text-xs" onClick={(event) => handleAction(event, 'compare', stock)}>
+                                                        Compare
+                                                    </button>
+                                                </div>
                                             </td>
                                         </tr>
                                     );

--- a/frontend/src/components/ScreenerPage.test.js
+++ b/frontend/src/components/ScreenerPage.test.js
@@ -87,6 +87,7 @@ describe('ScreenerPage', () => {
 
     test('renders presets, scan results, and routes row clicks into Search', async () => {
         const onSearchTicker = jest.fn();
+        const onScreenerAction = jest.fn();
         apiRequest.mockImplementation((url) => {
             if (url === API_ENDPOINTS.SCREENER_PRESETS) {
                 return Promise.resolve(presetsPayload);
@@ -97,10 +98,13 @@ describe('ScreenerPage', () => {
             if (url.includes('/screener/scan?preset=momentum_leaders')) {
                 return Promise.resolve(momentumPayload);
             }
+            if (url.includes('/watchlist/AAPL')) {
+                return Promise.resolve({ message: 'AAPL added to watchlist.' });
+            }
             throw new Error(`Unhandled request: ${url}`);
         });
 
-        render(<ScreenerPage onSearchTicker={onSearchTicker} />);
+        render(<ScreenerPage onSearchTicker={onSearchTicker} onScreenerAction={onScreenerAction} />);
 
         expect(await screen.findByText('Apple Inc.')).toBeInTheDocument();
         expect(screen.getByText('Momentum Leaders')).toBeInTheDocument();
@@ -108,10 +112,32 @@ describe('ScreenerPage', () => {
         fireEvent.click(screen.getByText('Apple Inc.'));
         expect(onSearchTicker).toHaveBeenCalledWith('AAPL');
 
+        fireEvent.click(screen.getByRole('button', { name: 'Predict' }));
+        expect(onScreenerAction).toHaveBeenCalledWith(expect.objectContaining({
+            action: 'predictions',
+            ticker: 'AAPL',
+        }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Watchlist' }));
+        await waitFor(() => {
+            expect(apiRequest).toHaveBeenCalledWith(expect.stringContaining('/watchlist/AAPL'), { method: 'POST' });
+        });
+        expect(await screen.findByText('AAPL added to watchlist.')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+        expect(await screen.findByText(/AAPL set as compare base/i)).toBeInTheDocument();
+
         fireEvent.click(screen.getByText('Momentum Leaders'));
 
         expect(await screen.findByText('Microsoft Corporation')).toBeInTheDocument();
         expect(screen.getAllByText('Showing the last good screener snapshot while fresh data reloads.').length).toBeGreaterThan(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+        expect(onScreenerAction).toHaveBeenCalledWith(expect.objectContaining({
+            action: 'compare',
+            ticker: 'AAPL',
+            compareTicker: 'MSFT',
+        }));
     });
 
     test('applies screener filters through the scan endpoint', async () => {

--- a/frontend/src/components/SearchPage.js
+++ b/frontend/src/components/SearchPage.js
@@ -279,7 +279,7 @@ const mapScreenerSuggestion = (stock = {}) => ({
     volume: typeof stock.volume === 'number' ? stock.volume : 0,
 });
 
-const SearchPage = ({ onNavigateToPredictions, initialTicker, onClearInitialTicker }) => {
+const SearchPage = ({ onNavigateToPredictions, initialTicker, initialCompareTicker, onClearInitialTicker }) => {
     const [loadingSuggestions, setLoadingSuggestions] = useState(false);
     const [expandedSectors, setExpandedSectors] = useState({});
     // --- NEW: Autocomplete states ---
@@ -375,11 +375,23 @@ const SearchPage = ({ onNavigateToPredictions, initialTicker, onClearInitialTick
 
     useEffect(() => {
         if (initialTicker) {
-            runSearch(initialTicker);
+            (async () => {
+                await runSearch(initialTicker);
+                if (initialCompareTicker) {
+                    try {
+                        await fetchComparisonBundle(
+                            String(initialCompareTicker).trim().toUpperCase(),
+                            timeFrames.find(f => f.value === '14d')
+                        );
+                    } catch {
+                        setComparisonData(null);
+                    }
+                }
+            })();
             if (onClearInitialTicker) onClearInitialTicker();
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [initialTicker]);
+    }, [initialTicker, initialCompareTicker]);
 
     useEffect(() => {
         // Load recent searches from localStorage

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -14,6 +14,7 @@ const NAV_GROUPS = [
     {
         label: 'Home',
         items: [
+            { page: 'screener', icon: SlidersHorizontal, label: 'Screener' },
             { page: 'dashboard', icon: LayoutDashboard, label: 'Dashboard' },
         ],
     },
@@ -21,7 +22,6 @@ const NAV_GROUPS = [
         label: 'Research',
         items: [
             { page: 'search', icon: Search, label: 'Search' },
-            { page: 'screener', icon: SlidersHorizontal, label: 'Screener' },
             { page: 'fundamentals', icon: Building2, label: 'Fundamentals' },
             { page: 'predictions', icon: TrendingUp, label: 'Predictions' },
             { page: 'performance', icon: Target, label: 'Evaluate' },


### PR DESCRIPTION
## Summary
- makes Screener the signed-in default entry page and moves it to the Home section of the sidebar
- adds Screener launch paths into Search, Predictions, Fundamentals, MarketMindAI, Watchlist, Paper Trading, and Search compare
- adds row-level reasons/action buttons so Screener becomes a find -> validate -> act workflow

Closes #119

## Verification
- CI=true npm test -- --watchAll=false --runInBand ScreenerPage.test.js Sidebar.test.js PredictionsPage.test.js FundamentalsPage.test.js PaperTradingPage.test.js MarketMindAIPage.test.js SearchPage.test.js
- npm run build