### PR TITLE
Backend refactor (part 3): centralize env/config loading (B8)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -22,14 +22,10 @@ import math
 from io import BytesIO
 from functools import wraps
 
-# --- DOTENV MUST BE FIRST ---
-from dotenv import load_dotenv
-
-CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT_DIR = os.path.dirname(CURRENT_FILE_DIR)
-load_dotenv(os.path.join(PROJECT_ROOT_DIR, '.env'))
-load_dotenv(os.path.join(CURRENT_FILE_DIR, '.env'), override=True)
-# --- END FIX ---
+# Load environment variables (project-root .env then backend/.env override).
+# Importing config performs the dotenv load once for the whole backend, so this
+# must come before any later import/read of environment-derived values.
+import config
 
 # --- OpenBB (optional, used for financials/filings/screener/macro) ---
 try:
@@ -264,8 +260,8 @@ def create_app(config=None):
     return app
 
 # --- CONFIGURATION ---
-NEWS_API_KEY = os.getenv('NEWS_API_KEY')
-ALPHA_VANTAGE_API_KEY = os.getenv('ALPHA_VANTAGE_API_KEY')
+NEWS_API_KEY = config.NEWS_API_KEY
+ALPHA_VANTAGE_API_KEY = config.ALPHA_VANTAGE_API_KEY
 
 # Validate required environment variables in production
 if IS_PRODUCTION:

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,23 @@
+"""Centralized backend configuration.
+
+Loads environment variables exactly once and in the original order —
+project-root ``.env`` first, then ``backend/.env`` which overrides it — and
+exposes the provider credentials the fetchers and API read. Importing this
+module is the single place that performs dotenv loading for the backend, so
+individual modules no longer each call ``load_dotenv()``.
+"""
+import os
+
+from dotenv import load_dotenv
+
+_BACKEND_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_BACKEND_DIR)
+
+# Two-stage load: project-root .env first, then backend/.env overrides it.
+load_dotenv(os.path.join(_PROJECT_ROOT, '.env'))
+load_dotenv(os.path.join(_BACKEND_DIR, '.env'), override=True)
+
+# --- Provider API keys ---
+ALPHA_VANTAGE_API_KEY = os.getenv('ALPHA_VANTAGE_API_KEY')
+NEWS_API_KEY = os.getenv('NEWS_API_KEY')
+FINNHUB_API_KEY = os.getenv('FINNHUB_API_KEY')

--- a/backend/crypto_fetcher.py
+++ b/backend/crypto_fetcher.py
@@ -1,13 +1,9 @@
 """
 Cryptocurrency exchange data fetcher using Alpha Vantage
 """
-import os
 import requests
-from dotenv import load_dotenv
 
-load_dotenv()
-
-ALPHA_VANTAGE_API_KEY = os.getenv('ALPHA_VANTAGE_API_KEY')
+from config import ALPHA_VANTAGE_API_KEY
 
 
 def get_crypto_exchange_rate(from_crypto='BTC', to_currency='USD'):

--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -1,18 +1,14 @@
 """
 Data fetcher with Alpha Vantage (primary) and yfinance (fallback)
 """
-import os
 import pandas as pd
 import numpy as np
 import requests
 import yfinance as yf
 from datetime import datetime, timedelta
-from dotenv import load_dotenv
 import time
 
-load_dotenv()
-
-ALPHA_VANTAGE_API_KEY = os.getenv('ALPHA_VANTAGE_API_KEY')
+from config import ALPHA_VANTAGE_API_KEY
 
 
 def fetch_stock_data(ticker, source='alpha_vantage', outputsize='full'):

--- a/backend/forex_fetcher.py
+++ b/backend/forex_fetcher.py
@@ -1,13 +1,9 @@
 """
 Forex (Foreign Exchange) data fetcher using Alpha Vantage
 """
-import os
 import requests
-from dotenv import load_dotenv
 
-load_dotenv()
-
-ALPHA_VANTAGE_API_KEY = os.getenv('ALPHA_VANTAGE_API_KEY')
+from config import ALPHA_VANTAGE_API_KEY
 
 
 def get_exchange_rate(from_currency='USD', to_currency='EUR'):

--- a/backend/news_fetcher.py
+++ b/backend/news_fetcher.py
@@ -1,10 +1,7 @@
-import os
 import finnhub
-from dotenv import load_dotenv
 import sentiment_service
 
-# Load environment variables from .env file
-load_dotenv()
+from config import FINNHUB_API_KEY
 
 def get_general_news(category='general', count=15):
     """
@@ -18,7 +15,7 @@ def get_general_news(category='general', count=15):
         list: A list of news article dictionaries, or an empty list if an error occurs.
     """
     try:
-        api_key = os.getenv('FINNHUB_API_KEY')
+        api_key = FINNHUB_API_KEY
         if not api_key:
             raise ValueError("FINNHUB_API_KEY not found in environment variables.")
 


### PR DESCRIPTION
## Summary

Centralizes backend environment/config loading (B8). **Behavior-preserving.**

- New **`backend/config.py`** performs the dotenv load once, in the original order — project-root `.env` first, then `backend/.env` with `override=True` — and exposes the provider API keys (`ALPHA_VANTAGE_API_KEY`, `NEWS_API_KEY`, `FINNHUB_API_KEY`).
- `api.py` and the `crypto`/`forex`/`data`/`news` fetchers now import from `config` instead of each calling `load_dotenv()` + `os.getenv()` independently (removing 4 duplicate `load_dotenv()` calls and their imports).

## Why it's behavior-preserving

`api.py` already ran the two-stage `.env` load at import, *before* importing the fetchers, so the fetchers' bare `load_dotenv()` was effectively redundant — they already saw the same environment. `config.py` reproduces that exact two-stage order, so every key resolves to the same value. Verified: `api.NEWS_API_KEY`/`ALPHA_VANTAGE_API_KEY` equal `config`'s, and the test that monkeypatches `api.ALPHA_VANTAGE_API_KEY` still works (it's still a module global, just initialized from config).

## Verification

Full per-module sweep: **29 pass**, same 5 environment-only failures as baseline (local numpy/cv2 ABI segfaults, missing `pypfopt`, flask-limiter rate-limit ordering) — **no regressions**.

## Scope note

The **logging-unification** half of the original B8 was intentionally **dropped**: `logger_config.setup_logger` emits a different format plus ANSI colors and rotating **file** handlers than api.py's stdout logger, so adopting it would change production log output — a behavior change, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
