### PR TITLE
Frontend refactor (F2): useApiData hook + NewsPage adoption

### DIFF
--- a/frontend/src/components/NewsPage.js
+++ b/frontend/src/components/NewsPage.js
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Search, TrendingUp, Zap, Globe, RefreshCw, Filter } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import { useApiData } from '../hooks/useApiData';
 import { getSentimentLabel, getSentimentToneClasses } from './ui/sentimentUtils';
 
 const NEWS_IMAGE_PLACEHOLDER = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(`
@@ -17,11 +18,24 @@ const NEWS_IMAGE_PLACEHOLDER = `data:image/svg+xml;charset=UTF-8,${encodeURIComp
 `)}`;
 
 const NewsPage = () => {
-    const [articles, setArticles] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState('');
     const [searchQuery, setSearchQuery] = useState('');
     const [activeCategory, setActiveCategory] = useState('General');
+
+    const newsFetcher = useCallback((query = '', category = 'General') => {
+        const useSearch = query || category !== 'General';
+        const endpoint = useSearch ? API_ENDPOINTS.NEWS(query || category) : API_ENDPOINTS.NEWS();
+        return apiRequest(endpoint).then((data) =>
+            (Array.isArray(data) ? data : []).map(normalizeArticle)
+        );
+        // normalizeArticle is a stable pure transform defined in this component.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const { data: articles, loading, error, refetch: fetchNews } = useApiData(
+        newsFetcher,
+        [],
+        { initialData: [], clearOnFetch: true }
+    );
 
     const categories = [
         { id: 'General', label: 'Top Stories', icon: Globe },
@@ -64,34 +78,6 @@ const NewsPage = () => {
             sentiment: article.sentiment || null,
         };
     };
-
-    const fetchNews = async (query = '', category = 'General') => {
-        setLoading(true);
-        setError('');
-        setArticles([]);
-
-        try {
-            let data;
-            if (query || category !== 'General') {
-                const searchTerm = query || category;
-                data = await apiRequest(API_ENDPOINTS.NEWS(searchTerm));
-            } else {
-                data = await apiRequest(API_ENDPOINTS.NEWS());
-            }
-
-            const rawArticles = Array.isArray(data) ? data : [];
-            setArticles(rawArticles.map(normalizeArticle));
-        } catch (err) {
-            setError(err.message);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    useEffect(() => {
-        fetchNews();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     const handleSearchSubmit = (e) => {
         e.preventDefault();

--- a/frontend/src/hooks/useApiData.js
+++ b/frontend/src/hooks/useApiData.js
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * useApiData — shared data-fetching state for the common
+ * "loading / error / data" page pattern, replacing the repeated
+ * setLoading(true) / try / await apiRequest / catch setError / finally
+ * setLoading(false) boilerplate.
+ *
+ * The `fetcher` is any async function (typically one that calls
+ * `apiRequest(API_ENDPOINTS.X(...))`). It may return already-transformed data.
+ * `refetch(...args)` forwards its arguments to the fetcher, so pages that fetch
+ * with parameters (search terms, filters) can call `refetch(query)`.
+ *
+ * Errors are surfaced as `error` (the thrown Error's `.message`), matching the
+ * existing `apiRequest` contract. A mounted-guard prevents state updates after
+ * unmount (a latent-bug fix that does not change rendered output).
+ *
+ * @param {(...args: any[]) => Promise<any>} fetcher
+ * @param {any[]} deps  re-run the immediate fetch when these change (like useEffect deps)
+ * @param {object} [options]
+ * @param {boolean} [options.immediate=true]     fetch once on mount / when deps change
+ * @param {any}     [options.initialData=null]   initial value for `data`
+ * @param {boolean} [options.clearOnFetch=false] reset `data` to initialData at the start of each fetch
+ * @returns {{ data: any, loading: boolean, error: string, refetch: (...args:any[]) => Promise<any>, setData: Function }}
+ */
+export function useApiData(fetcher, deps = [], options = {}) {
+    const { immediate = true, initialData = null, clearOnFetch = false } = options;
+
+    const [data, setData] = useState(initialData);
+    const [loading, setLoading] = useState(immediate);
+    const [error, setError] = useState('');
+
+    const mountedRef = useRef(true);
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    // Keep the latest fetcher without making it a dependency of refetch, so
+    // inline-defined fetchers don't churn the callback identity.
+    const fetcherRef = useRef(fetcher);
+    fetcherRef.current = fetcher;
+
+    const refetch = useCallback(
+        async (...args) => {
+            setLoading(true);
+            setError('');
+            if (clearOnFetch) {
+                setData(initialData);
+            }
+            try {
+                const result = await fetcherRef.current(...args);
+                if (mountedRef.current) {
+                    setData(result);
+                }
+                return result;
+            } catch (err) {
+                if (mountedRef.current) {
+                    setError(err?.message ?? String(err));
+                }
+                return undefined;
+            } finally {
+                if (mountedRef.current) {
+                    setLoading(false);
+                }
+            }
+        },
+        [clearOnFetch, initialData]
+    );
+
+    useEffect(() => {
+        if (immediate) {
+            refetch();
+        }
+        // deps drive the immediate refetch; refetch identity is stable.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps);
+
+    return { data, loading, error, refetch, setData };
+}
+
+export default useApiData;

--- a/frontend/src/hooks/useApiData.test.js
+++ b/frontend/src/hooks/useApiData.test.js
@@ -1,0 +1,97 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useApiData } from './useApiData';
+
+describe('useApiData', () => {
+    test('immediate fetch: loading is true then resolves with data', async () => {
+        const fetcher = jest.fn().mockResolvedValue({ ok: 1 });
+        const { result } = renderHook(() => useApiData(fetcher, []));
+
+        expect(result.current.loading).toBe(true);
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        expect(result.current.data).toEqual({ ok: 1 });
+        expect(result.current.error).toBe('');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    test('error path surfaces the thrown message and leaves data at initial', async () => {
+        const fetcher = jest.fn().mockRejectedValue(new Error('boom'));
+        const { result } = renderHook(() => useApiData(fetcher, [], { initialData: [] }));
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.error).toBe('boom');
+        expect(result.current.data).toEqual([]);
+    });
+
+    test('immediate:false does not fetch on mount', () => {
+        const fetcher = jest.fn().mockResolvedValue(1);
+        const { result } = renderHook(() => useApiData(fetcher, [], { immediate: false }));
+
+        expect(result.current.loading).toBe(false);
+        expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    test('refetch forwards arguments to the fetcher and returns the result', async () => {
+        const fetcher = jest.fn((q) => Promise.resolve(`r:${q}`));
+        const { result } = renderHook(() => useApiData(fetcher, [], { immediate: false }));
+
+        let returned;
+        await act(async () => {
+            returned = await result.current.refetch('AAPL');
+        });
+
+        expect(returned).toBe('r:AAPL');
+        expect(fetcher).toHaveBeenCalledWith('AAPL');
+        expect(result.current.data).toBe('r:AAPL');
+        expect(result.current.error).toBe('');
+    });
+
+    test('clearOnFetch resets stale data when a subsequent fetch fails', async () => {
+        const fetcher = jest
+            .fn()
+            .mockResolvedValueOnce(['seed'])
+            .mockRejectedValueOnce(new Error('later failure'));
+        const { result } = renderHook(() =>
+            useApiData(fetcher, [], { immediate: false, initialData: [], clearOnFetch: true })
+        );
+
+        await act(async () => {
+            await result.current.refetch();
+        });
+        expect(result.current.data).toEqual(['seed']);
+
+        await act(async () => {
+            await result.current.refetch();
+        });
+        // clearOnFetch reset data to initialData at the start; the failed fetch
+        // leaves it cleared rather than showing stale results.
+        expect(result.current.data).toEqual([]);
+        expect(result.current.error).toBe('later failure');
+    });
+
+    test('changing deps triggers a refetch', async () => {
+        const fetcher = jest.fn().mockResolvedValue(1);
+        const { rerender } = renderHook(({ dep }) => useApiData(fetcher, [dep]), {
+            initialProps: { dep: 'a' },
+        });
+
+        await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+        rerender({ dep: 'b' });
+        await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    });
+
+    test('does not update state after unmount', async () => {
+        let resolveFetch;
+        const fetcher = jest.fn(() => new Promise((res) => { resolveFetch = res; }));
+        const { result, unmount } = renderHook(() => useApiData(fetcher, []));
+
+        const before = result.current;
+        unmount();
+        await act(async () => {
+            resolveFetch({ late: true });
+            await Promise.resolve();
+        });
+        // No throw, and the last-rendered snapshot is unchanged post-unmount.
+        expect(before.data).toBeNull();
+    });
+});


### PR DESCRIPTION
Adds a shared `useApiData` hook (7 unit tests) replacing the duplicated loading/error/try-catch fetch boilerplate, with a mounted-guard and parameterized `refetch`. First adoption in NewsPage (behavior-preserving; its test is the guardrail). 20 suites / 74 tests pass, build clean. Further page migrations are incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)