### PR TITLE
Frontend refactor (F3): NavigationContext (remove prop-drilling + consume pattern)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { SignedIn, SignedOut, useAuth } from '@clerk/clerk-react';
+import { NavigationProvider, useNavigation } from './context/NavigationContext';
 import LandingPage from './components/LandingPage';
 import AuthPage from './components/AuthPage';
 import AuthFetchBridge from './components/AuthFetchBridge';
@@ -34,14 +35,92 @@ const shouldHideLandingByDefault = () => {
     return window.localStorage.getItem(LANDING_VISIBILITY_KEY) === 'true';
 };
 
+function AppShell() {
+    const {
+        activePage,
+        setActivePage,
+        sharedTicker,
+        sharedCompareTicker,
+        sharedAiPrompt,
+        clearTicker,
+        clearCompareTicker,
+        clearAiPrompt,
+        screenerNav,
+        screenerAction,
+    } = useNavigation();
+    const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+    return (
+        <div className="app-shell flex h-screen overflow-hidden">
+            <Sidebar
+                activePage={activePage}
+                setActivePage={setActivePage}
+                isCollapsed={sidebarCollapsed}
+                onToggleCollapse={() => setSidebarCollapsed(prev => !prev)}
+            />
+
+            <main className={`app-shell-main flex-1 overflow-y-auto transition-all duration-300 ${sidebarCollapsed ? 'ml-16' : 'ml-56'}`}>
+                {activePage === 'dashboard' && <DashboardPage setActivePage={setActivePage} />}
+                {activePage === 'search' && (
+                    <SearchPage
+                        initialTicker={sharedTicker}
+                        initialCompareTicker={sharedCompareTicker}
+                        onClearInitialTicker={() => {
+                            clearTicker();
+                            clearCompareTicker();
+                        }}
+                    />
+                )}
+                {activePage === 'screener' && (
+                    <ScreenerPage
+                        onSearchTicker={screenerNav}
+                        onScreenerAction={screenerAction}
+                    />
+                )}
+                {activePage === 'macro' && <MacroPage />}
+                {activePage === 'watchlist' && <WatchlistPage />}
+                {activePage === 'portfolio' && (
+                    <PaperTradingPage
+                        initialTicker={sharedTicker}
+                        onConsumeInitialTicker={clearTicker}
+                    />
+                )}
+                {activePage === 'fundamentals' && (
+                    <FundamentalsPage
+                        initialTicker={sharedTicker}
+                        onConsumeInitialTicker={clearTicker}
+                    />
+                )}
+                {activePage === 'predictions' && (
+                    <PredictionsPage
+                        initialTicker={sharedTicker}
+                        onConsumeInitialTicker={clearTicker}
+                    />
+                )}
+                {activePage === 'performance' && <ModelPerformancePage />}
+                {activePage === 'options' && <OptionsPage />}
+                {activePage === 'forex' && <ForexPage />}
+                {activePage === 'crypto' && <CryptoPage />}
+                {activePage === 'commodities' && <CommoditiesPage />}
+                {activePage === 'news' && <NewsPage />}
+                {activePage === 'notifications' && <NotificationsPage />}
+                {activePage === 'predictionMarkets' && <PredictionMarketsPage />}
+                {activePage === 'marketmindAI' && (
+                    <MarketMindAIPage
+                        initialPrompt={sharedAiPrompt}
+                        onConsumeInitialPrompt={clearAiPrompt}
+                    />
+                )}
+                {activePage === 'gettingStarted' && <GettingStartedPage />}
+                {activePage === 'calendar' && <MarketCalendarPage />}
+            </main>
+        </div>
+    );
+}
+
 function App() {
     const { isLoaded, isSignedIn } = useAuth();
     const [showLanding, setShowLanding] = useState(() => !shouldHideLandingByDefault());
-    const [activePage, setActivePage] = useState('screener');
-    const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-    const [sharedTicker, setSharedTicker] = useState(null);
-    const [sharedCompareTicker, setSharedCompareTicker] = useState(null);
-    const [sharedAiPrompt, setSharedAiPrompt] = useState('');
     useEffect(() => {
         if (!isLoaded || !isSignedIn || typeof window === 'undefined') {
             return;
@@ -50,47 +129,6 @@ function App() {
         window.localStorage.setItem(LANDING_VISIBILITY_KEY, 'true');
         setShowLanding(false);
     }, [isLoaded, isSignedIn]);
-
-    const handleScreenerNav = (ticker) => {
-        setSharedTicker(ticker);
-        setSharedCompareTicker(null);
-        setActivePage('search');
-    };
-
-    const handleScreenerAction = ({ action, ticker, compareTicker }) => {
-        const normalizedTicker = String(ticker || '').trim().toUpperCase();
-        const normalizedCompareTicker = String(compareTicker || '').trim().toUpperCase();
-        if (!normalizedTicker) return;
-
-        setSharedTicker(normalizedTicker);
-        setSharedCompareTicker(null);
-        setSharedAiPrompt('');
-
-        if (action === 'predictions') {
-            setActivePage('predictions');
-            return;
-        }
-        if (action === 'fundamentals') {
-            setActivePage('fundamentals');
-            return;
-        }
-        if (action === 'paper') {
-            setActivePage('portfolio');
-            return;
-        }
-        if (action === 'ai') {
-            setSharedAiPrompt(`Analyze ${normalizedTicker} from the Screener. Summarize why it surfaced, what to validate next, and what risks to check before acting.`);
-            setActivePage('marketmindAI');
-            return;
-        }
-        if (action === 'compare' && normalizedCompareTicker) {
-            setSharedCompareTicker(normalizedCompareTicker);
-            setActivePage('search');
-            return;
-        }
-
-        setActivePage('search');
-    };
 
     const handleEnterApp = () => {
         if (typeof window !== 'undefined') {
@@ -118,70 +156,9 @@ function App() {
             </SignedOut>
 
             <SignedIn>
-                <div className="app-shell flex h-screen overflow-hidden">
-                    <Sidebar
-                        activePage={activePage}
-                        setActivePage={setActivePage}
-                        isCollapsed={sidebarCollapsed}
-                        onToggleCollapse={() => setSidebarCollapsed(prev => !prev)}
-                    />
-
-                    <main className={`app-shell-main flex-1 overflow-y-auto transition-all duration-300 ${sidebarCollapsed ? 'ml-16' : 'ml-56'}`}>
-                        {activePage === 'dashboard' && <DashboardPage setActivePage={setActivePage} />}
-                        {activePage === 'search' && (
-                            <SearchPage
-                                initialTicker={sharedTicker}
-                                initialCompareTicker={sharedCompareTicker}
-                                onClearInitialTicker={() => {
-                                    setSharedTicker(null);
-                                    setSharedCompareTicker(null);
-                                }}
-                            />
-                        )}
-                        {activePage === 'screener' && (
-                            <ScreenerPage
-                                onSearchTicker={handleScreenerNav}
-                                onScreenerAction={handleScreenerAction}
-                            />
-                        )}
-                        {activePage === 'macro' && <MacroPage />}
-                        {activePage === 'watchlist' && <WatchlistPage />}
-                        {activePage === 'portfolio' && (
-                            <PaperTradingPage
-                                initialTicker={sharedTicker}
-                                onConsumeInitialTicker={() => setSharedTicker(null)}
-                            />
-                        )}
-                        {activePage === 'fundamentals' && (
-                            <FundamentalsPage
-                                initialTicker={sharedTicker}
-                                onConsumeInitialTicker={() => setSharedTicker(null)}
-                            />
-                        )}
-                        {activePage === 'predictions' && (
-                            <PredictionsPage
-                                initialTicker={sharedTicker}
-                                onConsumeInitialTicker={() => setSharedTicker(null)}
-                            />
-                        )}
-                        {activePage === 'performance' && <ModelPerformancePage />}
-                        {activePage === 'options' && <OptionsPage />}
-                        {activePage === 'forex' && <ForexPage />}
-                        {activePage === 'crypto' && <CryptoPage />}
-                        {activePage === 'commodities' && <CommoditiesPage />}
-                        {activePage === 'news' && <NewsPage />}
-                        {activePage === 'notifications' && <NotificationsPage />}
-                        {activePage === 'predictionMarkets' && <PredictionMarketsPage />}
-                        {activePage === 'marketmindAI' && (
-                            <MarketMindAIPage
-                                initialPrompt={sharedAiPrompt}
-                                onConsumeInitialPrompt={() => setSharedAiPrompt('')}
-                            />
-                        )}
-                        {activePage === 'gettingStarted' && <GettingStartedPage />}
-                        {activePage === 'calendar' && <MarketCalendarPage />}
-                    </main>
-                </div>
+                <NavigationProvider>
+                    <AppShell />
+                </NavigationProvider>
             </SignedIn>
         </>
     );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,18 +36,7 @@ const shouldHideLandingByDefault = () => {
 };
 
 function AppShell() {
-    const {
-        activePage,
-        setActivePage,
-        sharedTicker,
-        sharedCompareTicker,
-        sharedAiPrompt,
-        clearTicker,
-        clearCompareTicker,
-        clearAiPrompt,
-        screenerNav,
-        screenerAction,
-    } = useNavigation();
+    const { activePage } = useNavigation();
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
     return (
@@ -59,37 +48,13 @@ function AppShell() {
 
             <main className={`app-shell-main flex-1 overflow-y-auto transition-all duration-300 ${sidebarCollapsed ? 'ml-16' : 'ml-56'}`}>
                 {activePage === 'dashboard' && <DashboardPage />}
-                {activePage === 'search' && (
-                    <SearchPage
-                        initialTicker={sharedTicker}
-                        initialCompareTicker={sharedCompareTicker}
-                        onClearInitialTicker={() => {
-                            clearTicker();
-                            clearCompareTicker();
-                        }}
-                    />
-                )}
+                {activePage === 'search' && <SearchPage />}
                 {activePage === 'screener' && <ScreenerPage />}
                 {activePage === 'macro' && <MacroPage />}
                 {activePage === 'watchlist' && <WatchlistPage />}
-                {activePage === 'portfolio' && (
-                    <PaperTradingPage
-                        initialTicker={sharedTicker}
-                        onConsumeInitialTicker={clearTicker}
-                    />
-                )}
-                {activePage === 'fundamentals' && (
-                    <FundamentalsPage
-                        initialTicker={sharedTicker}
-                        onConsumeInitialTicker={clearTicker}
-                    />
-                )}
-                {activePage === 'predictions' && (
-                    <PredictionsPage
-                        initialTicker={sharedTicker}
-                        onConsumeInitialTicker={clearTicker}
-                    />
-                )}
+                {activePage === 'portfolio' && <PaperTradingPage />}
+                {activePage === 'fundamentals' && <FundamentalsPage />}
+                {activePage === 'predictions' && <PredictionsPage />}
                 {activePage === 'performance' && <ModelPerformancePage />}
                 {activePage === 'options' && <OptionsPage />}
                 {activePage === 'forex' && <ForexPage />}
@@ -98,12 +63,7 @@ function AppShell() {
                 {activePage === 'news' && <NewsPage />}
                 {activePage === 'notifications' && <NotificationsPage />}
                 {activePage === 'predictionMarkets' && <PredictionMarketsPage />}
-                {activePage === 'marketmindAI' && (
-                    <MarketMindAIPage
-                        initialPrompt={sharedAiPrompt}
-                        onConsumeInitialPrompt={clearAiPrompt}
-                    />
-                )}
+                {activePage === 'marketmindAI' && <MarketMindAIPage />}
                 {activePage === 'gettingStarted' && <GettingStartedPage />}
                 {activePage === 'calendar' && <MarketCalendarPage />}
             </main>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,14 +53,12 @@ function AppShell() {
     return (
         <div className="app-shell flex h-screen overflow-hidden">
             <Sidebar
-                activePage={activePage}
-                setActivePage={setActivePage}
                 isCollapsed={sidebarCollapsed}
                 onToggleCollapse={() => setSidebarCollapsed(prev => !prev)}
             />
 
             <main className={`app-shell-main flex-1 overflow-y-auto transition-all duration-300 ${sidebarCollapsed ? 'ml-16' : 'ml-56'}`}>
-                {activePage === 'dashboard' && <DashboardPage setActivePage={setActivePage} />}
+                {activePage === 'dashboard' && <DashboardPage />}
                 {activePage === 'search' && (
                     <SearchPage
                         initialTicker={sharedTicker}
@@ -71,12 +69,7 @@ function AppShell() {
                         }}
                     />
                 )}
-                {activePage === 'screener' && (
-                    <ScreenerPage
-                        onSearchTicker={screenerNav}
-                        onScreenerAction={screenerAction}
-                    />
-                )}
+                {activePage === 'screener' && <ScreenerPage />}
                 {activePage === 'macro' && <MacroPage />}
                 {activePage === 'watchlist' && <WatchlistPage />}
                 {activePage === 'portfolio' && (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -35,14 +35,20 @@ jest.mock('./components/AuthPage', () => ({ onBack }) => (
 
 jest.mock('./components/AuthFetchBridge', () => () => <div data-testid="auth-fetch-bridge" />);
 
-jest.mock('./components/Sidebar', () => ({ setActivePage }) => (
-    <div>
-        <p>Sidebar</p>
-        <button onClick={() => setActivePage('dashboard')}>Go Dashboard</button>
-        <button onClick={() => setActivePage('screener')}>Go Screener</button>
-        <button onClick={() => setActivePage('search')}>Go Search</button>
-    </div>
-));
+jest.mock('./components/Sidebar', () => {
+    const { useNavigation } = require('./context/NavigationContext');
+    return function SidebarMock() {
+        const { setActivePage } = useNavigation();
+        return (
+            <div>
+                <p>Sidebar</p>
+                <button onClick={() => setActivePage('dashboard')}>Go Dashboard</button>
+                <button onClick={() => setActivePage('screener')}>Go Screener</button>
+                <button onClick={() => setActivePage('search')}>Go Search</button>
+            </div>
+        );
+    };
+});
 
 jest.mock('./components/DashboardPage', () => () => <div>Dashboard Page</div>);
 jest.mock('./components/GettingStartedPage', () => () => <div>Getting Started Page</div>);
@@ -62,16 +68,26 @@ jest.mock('./components/MarketCalendarPage', () => () => <div>Market Calendar Pa
 jest.mock('./components/MacroPage', () => () => <div>Macro Page</div>);
 jest.mock('./components/MarketMindAIPage', () => () => <div>MarketMindAI Page</div>);
 
-jest.mock('./components/ScreenerPage', () => ({ onSearchTicker }) => (
-    <div>
-        <p>Screener Page</p>
-        <button onClick={() => onSearchTicker('AAPL')}>Pick AAPL</button>
-    </div>
-));
+jest.mock('./components/ScreenerPage', () => {
+    const { useNavigation } = require('./context/NavigationContext');
+    return function ScreenerMock() {
+        const { screenerNav } = useNavigation();
+        return (
+            <div>
+                <p>Screener Page</p>
+                <button onClick={() => screenerNav('AAPL')}>Pick AAPL</button>
+            </div>
+        );
+    };
+});
 
-jest.mock('./components/SearchPage', () => ({ initialTicker }) => (
-    <div>Search Page {initialTicker ? `for ${initialTicker}` : ''}</div>
-));
+jest.mock('./components/SearchPage', () => {
+    const { useNavigation } = require('./context/NavigationContext');
+    return function SearchMock() {
+        const { sharedTicker } = useNavigation();
+        return <div>Search Page {sharedTicker ? `for ${sharedTicker}` : ''}</div>;
+    };
+});
 
 describe('App', () => {
     beforeEach(() => {

--- a/frontend/src/components/DashboardPage.js
+++ b/frontend/src/components/DashboardPage.js
@@ -4,6 +4,7 @@ import {
     DollarSign, Newspaper, Bell, ArrowUpRight, ArrowDownRight
 } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import { useNavigation } from '../context/NavigationContext';
 
 const MARKET_TICKERS = [
     { ticker: 'SPY', label: 'S&P 500' },
@@ -274,7 +275,8 @@ function TopNewsSection({ setActivePage }) {
     );
 }
 
-const DashboardPage = ({ setActivePage }) => {
+const DashboardPage = () => {
+    const { setActivePage } = useNavigation();
     return (
         <div className="ui-page animate-fade-in space-y-2">
             <div className="ui-page-header">

--- a/frontend/src/components/DashboardPage.test.js
+++ b/frontend/src/components/DashboardPage.test.js
@@ -1,6 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import DashboardPage from './DashboardPage';
+import NavigationContext from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+
+const renderDashboard = () =>
+    render(
+        <NavigationContext.Provider value={{ setActivePage: () => {} }}>
+            <DashboardPage />
+        </NavigationContext.Provider>
+    );
 
 jest.mock('../config/api', () => ({
     API_ENDPOINTS: {
@@ -54,7 +62,7 @@ describe('DashboardPage portfolio summary', () => {
     });
 
     test('treats options positions as active positions in the portfolio summary card', async () => {
-        render(<DashboardPage setActivePage={() => {}} />);
+        renderDashboard();
 
         await waitFor(() => {
             expect(screen.getByText('$100,250.00')).toBeInTheDocument();
@@ -94,7 +102,7 @@ describe('DashboardPage portfolio summary', () => {
             return Promise.resolve([]);
         });
 
-        render(<DashboardPage setActivePage={() => {}} />);
+        renderDashboard();
 
         await waitFor(() => {
             expect(screen.getByText('No active positions')).toBeInTheDocument();

--- a/frontend/src/components/FundamentalsPage.js
+++ b/frontend/src/components/FundamentalsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigation } from '../context/NavigationContext';
 import {
     Building2,
     Search,
@@ -266,7 +267,8 @@ const AnnouncementsPanel = ({ items }) => {
     );
 };
 
-const FundamentalsPage = ({ initialTicker, onConsumeInitialTicker }) => {
+const FundamentalsPage = () => {
+    const { sharedTicker: initialTicker, clearTicker: onConsumeInitialTicker } = useNavigation();
     const [ticker, setTicker] = useState('');
     const [selectedMarket, setSelectedMarket] = useState('us');
     const [resolvedAsset, setResolvedAsset] = useState(null);

--- a/frontend/src/components/FundamentalsPage.test.js
+++ b/frontend/src/components/FundamentalsPage.test.js
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import FundamentalsPage from './FundamentalsPage';
+import { NavigationProvider } from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
 jest.mock('../config/api', () => ({
@@ -204,7 +205,7 @@ describe('FundamentalsPage', () => {
             .mockResolvedValueOnce(secIntelligencePayload)
             .mockResolvedValueOnce(filingDetailPayload);
 
-        render(<FundamentalsPage />);
+        render(<NavigationProvider><FundamentalsPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/Enter ticker/i), { target: { value: 'AAPL' } });
         fireEvent.click(screen.getByRole('button', { name: 'Search' }));
@@ -244,7 +245,7 @@ describe('FundamentalsPage', () => {
             .mockRejectedValueOnce(new Error('detail unavailable'))
             .mockRejectedValueOnce(new Error('detail unavailable'));
 
-        render(<FundamentalsPage />);
+        render(<NavigationProvider><FundamentalsPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/Enter ticker/i), { target: { value: 'AAPL' } });
         fireEvent.click(screen.getByRole('button', { name: 'Search' }));
@@ -267,7 +268,7 @@ describe('FundamentalsPage', () => {
     test('uses Akshare-backed company research mode for HK assets without calling SEC routes', async () => {
         apiRequest.mockResolvedValueOnce(hkFundamentalsPayload);
 
-        render(<FundamentalsPage />);
+        render(<NavigationProvider><FundamentalsPage /></NavigationProvider>);
 
         fireEvent.click(screen.getByRole('button', { name: 'HK' }));
         fireEvent.change(screen.getByPlaceholderText(/Enter ticker/i), { target: { value: '00700' } });

--- a/frontend/src/components/MarketMindAIPage.js
+++ b/frontend/src/components/MarketMindAIPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useEffectEvent, useMemo, useState } from 'react';
 import { useAuth } from '@clerk/clerk-react';
+import { useNavigation } from '../context/NavigationContext';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -283,7 +284,8 @@ const ArtifactPreview = ({ artifact, version }) => {
     );
 };
 
-const MarketMindAIPage = ({ initialPrompt, onConsumeInitialPrompt }) => {
+const MarketMindAIPage = () => {
+    const { sharedAiPrompt: initialPrompt, clearAiPrompt: onConsumeInitialPrompt } = useNavigation();
     const { isLoaded, isSignedIn } = useAuth();
     const [bootstrap, setBootstrap] = useState({ starterPrompts: [], templates: [] });
     const [activeChatId, setActiveChatId] = useState(null);

--- a/frontend/src/components/MarketMindAIPage.test.js
+++ b/frontend/src/components/MarketMindAIPage.test.js
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MarketMindAIPage from './MarketMindAIPage';
+import { NavigationProvider } from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
 jest.mock('react-markdown', () => ({ children }) => <div>{children}</div>);
@@ -87,7 +88,7 @@ describe('MarketMindAIPage', () => {
             throw new Error(`Unhandled url ${url}`);
         });
 
-        render(<MarketMindAIPage />);
+        render(<NavigationProvider><MarketMindAIPage /></NavigationProvider>);
 
         expect(await screen.findByRole('button', { name: /New chat/i })).toBeInTheDocument();
         expect(await screen.findByText(/What are the biggest risks to AAPL/i)).toBeInTheDocument();
@@ -236,7 +237,7 @@ describe('MarketMindAIPage', () => {
             throw new Error(`Unhandled url ${url}`);
         });
 
-        render(<MarketMindAIPage />);
+        render(<NavigationProvider><MarketMindAIPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/Ask MarketMindAI about a ticker/i), {
             target: { value: 'Summarize the current setup for NVDA using predictions, news, and fundamentals.' },
@@ -386,7 +387,7 @@ describe('MarketMindAIPage', () => {
             throw new Error(`Unhandled url ${url}`);
         });
 
-        render(<MarketMindAIPage />);
+        render(<NavigationProvider><MarketMindAIPage /></NavigationProvider>);
 
         window.dispatchEvent(new CustomEvent('marketmindai:select-chat', { detail: { chatId: 'chat-good' } }));
 
@@ -448,7 +449,7 @@ describe('MarketMindAIPage', () => {
             throw new Error(`Unhandled url ${url}`);
         });
 
-        render(<MarketMindAIPage />);
+        render(<NavigationProvider><MarketMindAIPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/Ask MarketMindAI about a ticker/i), {
             target: { value: 'Compare MSFT vs GOOGL using predictions, news, and fundamentals.' },
@@ -509,7 +510,7 @@ describe('MarketMindAIPage', () => {
             throw new Error(`Unhandled url ${url}`);
         });
 
-        render(<MarketMindAIPage />);
+        render(<NavigationProvider><MarketMindAIPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/Ask MarketMindAI about a ticker/i), {
             target: { value: 'Tell me about GOOGL.' },

--- a/frontend/src/components/PaperTradingPage.js
+++ b/frontend/src/components/PaperTradingPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigation } from '../context/NavigationContext';
 import {
   Briefcase,
   TrendingUp,
@@ -384,7 +385,8 @@ const holdingsEmptyClass = 'ui-panel-subtle border-dashed py-20 text-center';
 const positionCardClass = 'ui-panel p-6 transition-all';
 
 // --- MAIN APPLICATION COMPONENT ---
-export default function PaperTradingPage({ initialTicker, onConsumeInitialTicker }) {
+export default function PaperTradingPage() {
+    const { sharedTicker: initialTicker, clearTicker: onConsumeInitialTicker } = useNavigation();
     const [portfolio, setPortfolio] = useState(null);
     const [stockPositions, setStockPositions] = useState([]);
     const [optionsPositions, setOptionsPositions] = useState([]);

--- a/frontend/src/components/PaperTradingPage.test.js
+++ b/frontend/src/components/PaperTradingPage.test.js
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import PaperTradingPage from './PaperTradingPage';
+import { NavigationProvider } from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
 jest.mock('react-chartjs-2', () => ({
@@ -157,7 +158,7 @@ describe('PaperTradingPage', () => {
             throw new Error(`Unhandled request: ${url}`);
         });
 
-        render(<PaperTradingPage />);
+        render(<NavigationProvider><PaperTradingPage /></NavigationProvider>);
 
         expect(await screen.findByText('Rebalance Suggestions')).toBeInTheDocument();
         expect(await screen.findByText('Option positions are excluded from portfolio optimization v1.')).toBeInTheDocument();
@@ -193,7 +194,7 @@ describe('PaperTradingPage', () => {
             throw new Error(`Unhandled request: ${url}`);
         });
 
-        render(<PaperTradingPage />);
+        render(<NavigationProvider><PaperTradingPage /></NavigationProvider>);
 
         expect(await screen.findByText('Rebalance Suggestions')).toBeInTheDocument();
         expect(screen.getByText('Add at least two U.S. stock holdings to generate a portfolio rebalance plan.')).toBeInTheDocument();

--- a/frontend/src/components/PredictionsPage.js
+++ b/frontend/src/components/PredictionsPage.js
@@ -3,10 +3,12 @@ import StockPredictionCard from './ui/StockPredictionCard';
 import PredictionChart from './charts/PredictionChart';
 import ModelComparisonCard from './ui/ModelComparisonCard';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import { useNavigation } from '../context/NavigationContext';
 
 const DEFAULT_SINGLE_MODEL = 'LinReg';
 
-const PredictionsPage = ({ initialTicker, onConsumeInitialTicker }) => {
+const PredictionsPage = () => {
+    const { sharedTicker: initialTicker, clearTicker: onConsumeInitialTicker } = useNavigation();
     const [ticker, setTicker] = useState('');
     const [predictionData, setPredictionData] = useState(null);
     const [loading, setLoading] = useState(false);

--- a/frontend/src/components/PredictionsPage.test.js
+++ b/frontend/src/components/PredictionsPage.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import PredictionsPage from './PredictionsPage';
+import { NavigationProvider } from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
 jest.mock('./ui/StockPredictionCard', () => () => <div data-testid="stock-prediction-card" />);
@@ -29,7 +30,7 @@ describe('PredictionsPage', () => {
     });
 
     test('uses the ensemble endpoint by default', async () => {
-        render(<PredictionsPage />);
+        render(<NavigationProvider><PredictionsPage /></NavigationProvider>);
 
         expect(screen.getByText(/7 trading-session price predictions/i)).toBeInTheDocument();
 
@@ -46,7 +47,7 @@ describe('PredictionsPage', () => {
     });
 
     test('uses a valid default model in single-model mode', async () => {
-        render(<PredictionsPage />);
+        render(<NavigationProvider><PredictionsPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/enter stock ticker/i), {
             target: { value: 'AAPL' },
@@ -62,7 +63,7 @@ describe('PredictionsPage', () => {
     });
 
     test('uses the selected single model', async () => {
-        render(<PredictionsPage />);
+        render(<NavigationProvider><PredictionsPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText(/enter stock ticker/i), {
             target: { value: 'AAPL' },

--- a/frontend/src/components/ScreenerPage.js
+++ b/frontend/src/components/ScreenerPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigation } from '../context/NavigationContext';
 import {
     Activity,
     ArrowUpDown,
@@ -70,7 +71,8 @@ const columns = [
     { key: 'year_low', label: '52W Low', formatter: (value) => (value === null || value === undefined ? '—' : `$${Number(value).toFixed(2)}`) },
 ];
 
-const ScreenerPage = ({ onSearchTicker, onScreenerAction }) => {
+const ScreenerPage = () => {
+    const { screenerNav: onSearchTicker, screenerAction: onScreenerAction } = useNavigation();
     const [presets, setPresets] = useState([]);
     const [sectors, setSectors] = useState([]);
     const [activePreset, setActivePreset] = useState('gainers');

--- a/frontend/src/components/ScreenerPage.test.js
+++ b/frontend/src/components/ScreenerPage.test.js
@@ -1,6 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ScreenerPage from './ScreenerPage';
+import NavigationContext from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+
+const renderScreener = ({ screenerNav = jest.fn(), screenerAction = jest.fn() } = {}) =>
+    render(
+        <NavigationContext.Provider value={{ screenerNav, screenerAction }}>
+            <ScreenerPage />
+        </NavigationContext.Provider>
+    );
 
 jest.mock('../config/api', () => {
     const actual = jest.requireActual('../config/api');
@@ -104,7 +112,7 @@ describe('ScreenerPage', () => {
             throw new Error(`Unhandled request: ${url}`);
         });
 
-        render(<ScreenerPage onSearchTicker={onSearchTicker} onScreenerAction={onScreenerAction} />);
+        renderScreener({ screenerNav: onSearchTicker, screenerAction: onScreenerAction });
 
         expect(await screen.findByText('Apple Inc.')).toBeInTheDocument();
         expect(screen.getByText('Momentum Leaders')).toBeInTheDocument();
@@ -151,7 +159,7 @@ describe('ScreenerPage', () => {
             throw new Error(`Unhandled request: ${url}`);
         });
 
-        render(<ScreenerPage />);
+        renderScreener();
 
         await screen.findByText('Apple Inc.');
 

--- a/frontend/src/components/SearchPage.js
+++ b/frontend/src/components/SearchPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useNavigation } from '../context/NavigationContext';
 import { Search, TrendingUp, TrendingDown, Activity, Building, ChevronDown, ChevronUp } from 'lucide-react';
 import StockDataCard from './ui/StockDataCard';
 import StockChart from './charts/StockChart';
@@ -279,7 +280,17 @@ const mapScreenerSuggestion = (stock = {}) => ({
     volume: typeof stock.volume === 'number' ? stock.volume : 0,
 });
 
-const SearchPage = ({ onNavigateToPredictions, initialTicker, initialCompareTicker, onClearInitialTicker }) => {
+const SearchPage = ({ onNavigateToPredictions }) => {
+    const {
+        sharedTicker: initialTicker,
+        sharedCompareTicker: initialCompareTicker,
+        clearTicker,
+        clearCompareTicker,
+    } = useNavigation();
+    const onClearInitialTicker = () => {
+        clearTicker();
+        clearCompareTicker();
+    };
     const [loadingSuggestions, setLoadingSuggestions] = useState(false);
     const [expandedSectors, setExpandedSectors] = useState({});
     // --- NEW: Autocomplete states ---

--- a/frontend/src/components/SearchPage.test.js
+++ b/frontend/src/components/SearchPage.test.js
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import SearchPage from './SearchPage';
+import { NavigationProvider } from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 
 jest.mock('./ui/StockDataCard', () => ({ data }) => (
@@ -128,7 +129,7 @@ describe('SearchPage', () => {
             }
         });
 
-        render(<SearchPage />);
+        render(<NavigationProvider><SearchPage /></NavigationProvider>);
 
         fireEvent.click(await screen.findByRole('button', { name: /AAPL/i }));
         fireEvent.click(screen.getByRole('button', { name: /MSFT/i }));
@@ -183,7 +184,7 @@ describe('SearchPage', () => {
             }
         });
 
-        render(<SearchPage />);
+        render(<NavigationProvider><SearchPage /></NavigationProvider>);
 
         fireEvent.click(await screen.findByRole('button', { name: /AAPL/i }));
         fireEvent.click(screen.getByRole('button', { name: /MSFT/i }));
@@ -226,7 +227,7 @@ describe('SearchPage', () => {
             }
         });
 
-        render(<SearchPage />);
+        render(<NavigationProvider><SearchPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText('e.g., AAPL, HK:00700, CN:600519'), { target: { value: 'nv' } });
         fireEvent.mouseDown(await screen.findByText('NVDA'));
@@ -273,7 +274,7 @@ describe('SearchPage', () => {
             }
         });
 
-        render(<SearchPage />);
+        render(<NavigationProvider><SearchPage /></NavigationProvider>);
 
         fireEvent.click(await screen.findByRole('button', { name: 'TSLA' }));
         expect(await screen.findByTestId('stock-data')).toHaveTextContent('Tesla (TSLA)');
@@ -313,7 +314,7 @@ describe('SearchPage', () => {
             }
         });
 
-        render(<SearchPage />);
+        render(<NavigationProvider><SearchPage /></NavigationProvider>);
 
         fireEvent.change(screen.getByPlaceholderText('e.g., AAPL, HK:00700, CN:600519'), { target: { value: 'NVDA' } });
         fireEvent.click(screen.getByRole('button', { name: 'Search' }));
@@ -344,7 +345,7 @@ describe('SearchPage', () => {
             }
         });
 
-        render(<SearchPage />);
+        render(<NavigationProvider><SearchPage /></NavigationProvider>);
 
         fireEvent.click(screen.getByRole('button', { name: 'All' }));
         fireEvent.change(screen.getByPlaceholderText('e.g., AAPL, HK:00700, CN:600519'), { target: { value: '70' } });

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { UserButton } from '@clerk/clerk-react';
 import { useDarkMode } from '../context/DarkModeContext';
+import { useNavigation } from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
 import {
     LayoutDashboard, Search, Star, Briefcase, Building2,
@@ -62,7 +63,8 @@ const NAV_GROUPS = [
     },
 ];
 
-const Sidebar = ({ activePage, setActivePage, isCollapsed, onToggleCollapse }) => {
+const Sidebar = ({ isCollapsed, onToggleCollapse }) => {
+    const { activePage, setActivePage } = useNavigation();
     const { isDarkMode, toggleDarkMode } = useDarkMode();
     const [newAlertCount, setNewAlertCount] = useState(0);
     const [recentAiChats, setRecentAiChats] = useState([]);

--- a/frontend/src/components/Sidebar.test.js
+++ b/frontend/src/components/Sidebar.test.js
@@ -1,6 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Sidebar from './Sidebar';
+import NavigationContext from '../context/NavigationContext';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+
+const renderSidebar = (activePage = 'dashboard') =>
+    render(
+        <NavigationContext.Provider value={{ activePage, setActivePage: jest.fn() }}>
+            <Sidebar isCollapsed={false} onToggleCollapse={jest.fn()} />
+        </NavigationContext.Provider>
+    );
 
 jest.mock('@clerk/clerk-react', () => ({
     UserButton: () => <div>User Button</div>,
@@ -40,14 +48,7 @@ describe('Sidebar alert badge polling', () => {
     });
 
     test('checks triggered alerts with the non-destructive all=true query', async () => {
-        render(
-            <Sidebar
-                activePage="dashboard"
-                setActivePage={jest.fn()}
-                isCollapsed={false}
-                onToggleCollapse={jest.fn()}
-            />
-        );
+        renderSidebar('dashboard');
 
         await waitFor(() => {
             expect(API_ENDPOINTS.NOTIFICATIONS_TRIGGERED).toHaveBeenCalledWith(true);
@@ -57,14 +58,7 @@ describe('Sidebar alert badge polling', () => {
     });
 
     test('renders the workflow-first navigation groups', async () => {
-        render(
-            <Sidebar
-                activePage="dashboard"
-                setActivePage={jest.fn()}
-                isCollapsed={false}
-                onToggleCollapse={jest.fn()}
-            />
-        );
+        renderSidebar('dashboard');
 
         await waitFor(() => {
             expect(screen.getByText('Research')).toBeInTheDocument();
@@ -94,14 +88,7 @@ describe('Sidebar alert badge polling', () => {
             throw new Error(`Unhandled url ${url}`);
         });
 
-        render(
-            <Sidebar
-                activePage="marketmindAI"
-                setActivePage={jest.fn()}
-                isCollapsed={false}
-                onToggleCollapse={jest.fn()}
-            />
-        );
+        renderSidebar('marketmindAI');
 
         expect(await screen.findByText(/Analyze AAPL/i)).toBeInTheDocument();
 

--- a/frontend/src/context/NavigationContext.js
+++ b/frontend/src/context/NavigationContext.js
@@ -1,0 +1,119 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+/**
+ * NavigationContext centralizes app navigation and the one-shot "navigation
+ * intent" (a ticker / compare-ticker / AI prompt) that a destination page reads
+ * once on arrival. This replaces threading `activePage`/`setActivePage` and the
+ * `initialTicker` + `onConsumeInitialTicker` prop dance through App into every
+ * page.
+ *
+ * Pages read `activePage` and their intent (`sharedTicker`, etc.) via
+ * `useNavigation()`, and clear the intent with `clearTicker()` /
+ * `clearCompareTicker()` / `clearAiPrompt()` once consumed — the same
+ * read-once-then-clear semantics as before, now expressed in one place.
+ */
+const NavigationContext = createContext(null);
+
+const INITIAL_PAGE = 'screener';
+
+export function NavigationProvider({ children }) {
+    const [activePage, setActivePage] = useState(INITIAL_PAGE);
+    const [sharedTicker, setSharedTicker] = useState(null);
+    const [sharedCompareTicker, setSharedCompareTicker] = useState(null);
+    const [sharedAiPrompt, setSharedAiPrompt] = useState('');
+
+    const clearTicker = useCallback(() => setSharedTicker(null), []);
+    const clearCompareTicker = useCallback(() => setSharedCompareTicker(null), []);
+    const clearAiPrompt = useCallback(() => setSharedAiPrompt(''), []);
+
+    // Navigate to a page, optionally seeding the intent the destination reads.
+    const navigate = useCallback((page, intent = {}) => {
+        if ('ticker' in intent) setSharedTicker(intent.ticker);
+        if ('compareTicker' in intent) setSharedCompareTicker(intent.compareTicker);
+        if ('aiPrompt' in intent) setSharedAiPrompt(intent.aiPrompt);
+        setActivePage(page);
+    }, []);
+
+    // Screener "open ticker in search" — moved verbatim from App.handleScreenerNav.
+    const screenerNav = useCallback((ticker) => {
+        setSharedTicker(ticker);
+        setSharedCompareTicker(null);
+        setActivePage('search');
+    }, []);
+
+    // Screener action buttons — moved verbatim from App.handleScreenerAction.
+    const screenerAction = useCallback(({ action, ticker, compareTicker }) => {
+        const normalizedTicker = String(ticker || '').trim().toUpperCase();
+        const normalizedCompareTicker = String(compareTicker || '').trim().toUpperCase();
+        if (!normalizedTicker) return;
+
+        setSharedTicker(normalizedTicker);
+        setSharedCompareTicker(null);
+        setSharedAiPrompt('');
+
+        if (action === 'predictions') {
+            setActivePage('predictions');
+            return;
+        }
+        if (action === 'fundamentals') {
+            setActivePage('fundamentals');
+            return;
+        }
+        if (action === 'paper') {
+            setActivePage('portfolio');
+            return;
+        }
+        if (action === 'ai') {
+            setSharedAiPrompt(`Analyze ${normalizedTicker} from the Screener. Summarize why it surfaced, what to validate next, and what risks to check before acting.`);
+            setActivePage('marketmindAI');
+            return;
+        }
+        if (action === 'compare' && normalizedCompareTicker) {
+            setSharedCompareTicker(normalizedCompareTicker);
+            setActivePage('search');
+            return;
+        }
+
+        setActivePage('search');
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            activePage,
+            setActivePage,
+            navigate,
+            sharedTicker,
+            sharedCompareTicker,
+            sharedAiPrompt,
+            clearTicker,
+            clearCompareTicker,
+            clearAiPrompt,
+            screenerNav,
+            screenerAction,
+        }),
+        [
+            activePage,
+            sharedTicker,
+            sharedCompareTicker,
+            sharedAiPrompt,
+            navigate,
+            clearTicker,
+            clearCompareTicker,
+            clearAiPrompt,
+            screenerNav,
+            screenerAction,
+        ]
+    );
+
+    return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>;
+}
+
+export function useNavigation() {
+    const ctx = useContext(NavigationContext);
+    if (!ctx) {
+        throw new Error('useNavigation must be used within a NavigationProvider');
+    }
+    return ctx;
+}
+
+export default NavigationContext;

--- a/frontend/src/context/NavigationContext.test.js
+++ b/frontend/src/context/NavigationContext.test.js
@@ -1,0 +1,79 @@
+import { renderHook, act } from '@testing-library/react';
+import { NavigationProvider, useNavigation } from './NavigationContext';
+
+const wrapper = ({ children }) => <NavigationProvider>{children}</NavigationProvider>;
+
+describe('NavigationContext', () => {
+    test('defaults to the screener page with empty intent', () => {
+        const { result } = renderHook(() => useNavigation(), { wrapper });
+        expect(result.current.activePage).toBe('screener');
+        expect(result.current.sharedTicker).toBeNull();
+        expect(result.current.sharedCompareTicker).toBeNull();
+        expect(result.current.sharedAiPrompt).toBe('');
+    });
+
+    test('navigate seeds intent and switches page', () => {
+        const { result } = renderHook(() => useNavigation(), { wrapper });
+        act(() => result.current.navigate('fundamentals', { ticker: 'AAPL' }));
+        expect(result.current.activePage).toBe('fundamentals');
+        expect(result.current.sharedTicker).toBe('AAPL');
+    });
+
+    test('screenerNav opens the ticker in search and resets compare', () => {
+        const { result } = renderHook(() => useNavigation(), { wrapper });
+        act(() => result.current.navigate('search', { compareTicker: 'OLD' }));
+        act(() => result.current.screenerNav('MSFT'));
+        expect(result.current.activePage).toBe('search');
+        expect(result.current.sharedTicker).toBe('MSFT');
+        expect(result.current.sharedCompareTicker).toBeNull();
+    });
+
+    test('screenerAction routes each action to the right page (ticker normalized)', () => {
+        const { result } = renderHook(() => useNavigation(), { wrapper });
+
+        act(() => result.current.screenerAction({ action: 'predictions', ticker: 'aapl' }));
+        expect(result.current.activePage).toBe('predictions');
+        expect(result.current.sharedTicker).toBe('AAPL');
+
+        act(() => result.current.screenerAction({ action: 'fundamentals', ticker: 'aapl' }));
+        expect(result.current.activePage).toBe('fundamentals');
+
+        act(() => result.current.screenerAction({ action: 'paper', ticker: 'aapl' }));
+        expect(result.current.activePage).toBe('portfolio');
+
+        act(() => result.current.screenerAction({ action: 'ai', ticker: 'nvda' }));
+        expect(result.current.activePage).toBe('marketmindAI');
+        expect(result.current.sharedAiPrompt).toContain('NVDA');
+
+        act(() => result.current.screenerAction({ action: 'compare', ticker: 'aapl', compareTicker: 'msft' }));
+        expect(result.current.activePage).toBe('search');
+        expect(result.current.sharedTicker).toBe('AAPL');
+        expect(result.current.sharedCompareTicker).toBe('MSFT');
+    });
+
+    test('screenerAction ignores an empty ticker', () => {
+        const { result } = renderHook(() => useNavigation(), { wrapper });
+        act(() => result.current.screenerAction({ action: 'predictions', ticker: '   ' }));
+        expect(result.current.activePage).toBe('screener');
+        expect(result.current.sharedTicker).toBeNull();
+    });
+
+    test('clear functions reset the intent (read-once semantics)', () => {
+        const { result } = renderHook(() => useNavigation(), { wrapper });
+        act(() => result.current.navigate('search', { ticker: 'AAPL', compareTicker: 'MSFT', aiPrompt: 'x' }));
+        act(() => {
+            result.current.clearTicker();
+            result.current.clearCompareTicker();
+            result.current.clearAiPrompt();
+        });
+        expect(result.current.sharedTicker).toBeNull();
+        expect(result.current.sharedCompareTicker).toBeNull();
+        expect(result.current.sharedAiPrompt).toBe('');
+    });
+
+    test('useNavigation throws when used outside a provider', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() => renderHook(() => useNavigation())).toThrow(/NavigationProvider/);
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary

F3 — replace the hand-rolled navigation prop-drilling with a **NavigationContext**. Behavior-preserving; done incrementally (5 commits) with the test suite green at every step.

### What changed
- New **`context/NavigationContext.js`**: holds `activePage`, the one-shot navigation intent (`sharedTicker` / `sharedCompareTicker` / `sharedAiPrompt`) and `clearTicker/clearCompareTicker/clearAiPrompt`, plus `navigate()` and `screenerNav`/`screenerAction` (moved verbatim from App).
- **App** split into `App` (landing/auth + `<NavigationProvider>`) and `AppShell` (the switchboard, which now only reads `activePage`).
- Consumers migrated off props to `useNavigation()`:
  - **Sidebar / DashboardPage / ScreenerPage** → `activePage`/`setActivePage`/`screenerNav`/`screenerAction`.
  - **SearchPage / PaperTradingPage / FundamentalsPage / PredictionsPage / MarketMindAIPage** → read their intent and clear it via context, removing the `initialTicker` + `onConsumeInitialTicker` (and `onClearInitialTicker`/`initialPrompt`) "read-once-then-null" prop dance that was reimplemented in each.
- The `AppShell` switchboard now renders these pages **prop-less**.

### Why it's behavior-preserving
The read-once-then-clear semantics are identical — the default context intent is `null`/`''`, reproducing the old undefined-prop no-op; `screenerNav`/`screenerAction` were moved verbatim; and the per-page effects are unchanged (context values are aliased to the old prop names). Every page test now renders within a `NavigationProvider`.

### Tests
- All existing suites updated to render within the provider (mocks in `App.test`/`Sidebar.test`/`ScreenerPage.test`/`DashboardPage.test` now source from context).
- **New `NavigationContext.test.js`** (7 tests) covers `screenerNav`, `screenerAction` action-routing + ticker normalization, `navigate` seeding, the clears, and the outside-provider guard — closing a real gap (the mocked App test never exercised the screener→page intent flow).
- **21 suites / 81 tests pass; `CI=true` build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
