### PR TITLE
Backend refactor (B4): reduce DI verbosity for ambient dependencies

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -238,7 +238,6 @@ def add_security_headers(response):
         database_url=DATABASE_URL,
         increment_public_api_daily_usage_fn=increment_public_api_daily_usage_db,
         touch_public_api_key_last_used_fn=touch_public_api_key_last_used_db,
-        logger=logger,
     )
 
 @api_bp.app_errorhandler(RateLimitExceeded)
@@ -432,7 +431,6 @@ def _iter_user_ids():
         session_scope=user_state_session_scope,
         database_url=DATABASE_URL,
         list_app_user_ids_db_fn=list_app_user_ids_db,
-        logger=logger,
     )
 
 
@@ -497,7 +495,6 @@ def require_auth(f):
         token_getter=lambda: _get_clerk_bearer_token(),
         verify_token_fn=lambda token: verify_clerk_token(token),
         sync_authenticated_user_fn=lambda payload: _sync_authenticated_user(payload),
-        logger=logger,
         unauthorized_response_fn=lambda message, status: (jsonify({"error": message}), status),
         set_request_identity_fn=lambda payload: (
             setattr(g, 'current_user_id', payload['sub']),
@@ -564,7 +561,6 @@ def require_public_api_auth(route_group):
             authenticate_key_fn=_public_api_authenticate,
             get_daily_quota_fn=_public_api_daily_quota,
             get_daily_usage_total_fn=_public_api_daily_usage_total,
-            logger=logger,
             error_response_fn=_public_api_error_response,
         )
 
@@ -902,7 +898,6 @@ def get_deliverables():
         database_url=DATABASE_URL,
         list_deliverables_fn=list_deliverables,
         get_current_user_id_fn=get_current_user_id,
-        jsonify_fn=jsonify,
     )
 
 
@@ -921,7 +916,6 @@ def post_deliverable():
         create_deliverable_fn=create_deliverable,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -939,7 +933,6 @@ def get_deliverable(deliverable_id):
         get_deliverable_detail_fn=get_deliverable_detail,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -959,7 +952,6 @@ def patch_deliverable(deliverable_id):
         update_deliverable_fn=update_deliverable,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -979,7 +971,6 @@ def put_deliverable_assumptions(deliverable_id):
         replace_deliverable_assumptions_fn=replace_deliverable_assumptions,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -999,7 +990,6 @@ def post_deliverable_review(deliverable_id):
         add_deliverable_review_fn=add_deliverable_review,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1017,7 +1007,6 @@ def post_deliverable_preflight(deliverable_id):
         create_deliverable_preflight_fn=create_deliverable_preflight,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1035,7 +1024,6 @@ def get_deliverable_context(deliverable_id):
         build_deliverable_context_fn=build_deliverable_context,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1053,7 +1041,6 @@ def get_deliverable_memos(deliverable_id):
         list_deliverable_memos_fn=list_deliverable_memos,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1071,7 +1058,6 @@ def post_deliverable_generate(deliverable_id):
         generate_deliverable_memo_fn=generate_deliverable_memo,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1090,7 +1076,6 @@ def download_deliverable_memo(deliverable_id, memo_id):
         get_deliverable_memo_artifact_fn=get_deliverable_memo_artifact,
         get_current_user_id_fn=get_current_user_id,
         deliverable_error_cls=DeliverableError,
-        jsonify_fn=jsonify,
         bytes_io_cls=BytesIO,
         send_file_fn=send_file,
         docx_mime_type=DOCX_MIME_TYPE,
@@ -1105,7 +1090,6 @@ def get_marketmind_ai_bootstrap():
         deliverables_ready_fn=_deliverables_ready,
         not_configured_response_fn=_marketmind_ai_not_configured_response,
         get_bootstrap_payload_fn=get_marketmind_ai_bootstrap_payload,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1121,7 +1105,6 @@ def get_marketmind_ai_chats():
         database_url=DATABASE_URL,
         list_chats_fn=list_marketmind_ai_chats,
         get_current_user_id_fn=get_current_user_id,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1139,7 +1122,6 @@ def get_marketmind_ai_chat(chat_id):
         get_chat_detail_fn=get_marketmind_ai_chat_detail,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1157,7 +1139,6 @@ def delete_marketmind_ai_chat_route(chat_id):
         delete_chat_fn=delete_marketmind_ai_chat,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1178,7 +1159,6 @@ def get_marketmind_ai_context():
         build_context_fn=build_marketmind_ai_context,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1199,7 +1179,6 @@ def get_marketmind_ai_retrieval_status_route():
         get_retrieval_status_fn=get_marketmind_ai_retrieval_status,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1218,7 +1197,6 @@ def post_marketmind_ai_chat():
         generate_reply_fn=generate_marketmind_ai_reply,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1237,7 +1215,6 @@ def post_marketmind_ai_artifact_preflight():
         create_artifact_preflight_fn=create_artifact_preflight,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1253,7 +1230,6 @@ def get_marketmind_ai_artifacts():
         database_url=DATABASE_URL,
         list_artifacts_fn=list_marketmind_ai_artifacts,
         get_current_user_id_fn=get_current_user_id,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1272,7 +1248,6 @@ def post_marketmind_ai_artifact_generate():
         generate_artifact_fn=generate_marketmind_ai_artifact,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1290,7 +1265,6 @@ def get_marketmind_ai_artifact(artifact_id):
         get_artifact_detail_fn=get_marketmind_ai_artifact_detail,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1309,7 +1283,6 @@ def download_marketmind_ai_artifact(artifact_id, version_id):
         get_artifact_download_fn=get_marketmind_ai_artifact_download,
         get_current_user_id_fn=get_current_user_id,
         error_cls=MarketMindAIError,
-        jsonify_fn=jsonify,
         bytes_io_cls=BytesIO,
         send_file_fn=send_file,
         docx_mime_type=DOCX_MIME_TYPE,
@@ -1326,7 +1299,6 @@ def get_symbol_suggestions(query):
         query,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         requests_get=requests.get,
-        logger=logger,
     )
 
 
@@ -1338,7 +1310,6 @@ def get_watchlist():
     return market_data_handlers.get_watchlist_handler(
         get_current_user_id_fn=get_current_user_id,
         load_watchlist_fn=load_watchlist,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1351,7 +1322,6 @@ def add_to_watchlist(ticker):
         get_current_user_id_fn=get_current_user_id,
         load_watchlist_fn=load_watchlist,
         save_watchlist_fn=save_watchlist,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1364,7 +1334,6 @@ def remove_from_watchlist(ticker):
         get_current_user_id_fn=get_current_user_id,
         load_watchlist_fn=load_watchlist,
         save_watchlist_fn=save_watchlist,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1377,9 +1346,6 @@ def get_stock_data(ticker):
         request_obj=request,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         yf_module=yf,
-        requests_module=requests,
-        jsonify_fn=jsonify,
-        logger=logger,
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
@@ -1394,8 +1360,6 @@ def get_chart_data(ticker):
         ticker,
         request_obj=request,
         yf_module=yf,
-        jsonify_fn=jsonify,
-        logger=logger,
         clean_value_fn=clean_value,
         chart_prediction_points_fn=_chart_prediction_points,
         resolve_asset_fn=_resolve_market_asset,
@@ -1409,8 +1373,6 @@ def get_query_news():
     return market_data_handlers.get_query_news_handler(
         request_obj=request,
         news_api_key=NEWS_API_KEY,
-        requests_module=requests,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1420,7 +1382,6 @@ def get_options_stock_price(ticker):
     return market_data_handlers.get_options_stock_price_handler(
         ticker,
         yf_module=yf,
-        jsonify_fn=jsonify,
         clean_value_fn=clean_value,
     )
 
@@ -1430,7 +1391,6 @@ def get_option_expirations(ticker):
     return market_data_handlers.get_option_expirations_handler(
         ticker,
         yf_module=yf,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1440,9 +1400,6 @@ def get_option_chain(ticker):
         ticker,
         request_obj=request,
         yf_module=yf,
-        jsonify_fn=jsonify,
-        math_module=math,
-        logger=logger,
     )
 
 # --- Options Suggestion Endpoint ---
@@ -1451,8 +1408,6 @@ def get_option_suggestion(ticker):
     return market_data_handlers.get_option_suggestion_handler(
         ticker,
         generate_suggestion_fn=generate_suggestion,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1477,10 +1432,7 @@ def predict_stock(model, ticker):
         transformer_train_fn=transformer_train,
         transformer_predict_fn=transformer_predict,
         yf_module=yf,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
-        pd_module=pd,
     )
     return response
 
@@ -1493,7 +1445,6 @@ def _live_ensemble_signal_components(sanitized_ticker):
         sanitized_ticker,
         create_dataset_fn=create_dataset,
         ensemble_predict_fn=ensemble_predict,
-        np_module=np,
     )
 
 
@@ -1501,7 +1452,6 @@ def _chart_prediction_points(sanitized_ticker):
     return api_prediction_runtime_helpers.chart_prediction_points(
         sanitized_ticker,
         live_ensemble_signal_components_fn=_live_ensemble_signal_components,
-        pd_module=pd,
     )
 
 
@@ -1515,10 +1465,6 @@ def predict_ensemble(ticker):
         future_prediction_dates_fn=prediction_service.get_future_prediction_dates,
         yf_module=yf,
         live_ensemble_signal_components_fn=_live_ensemble_signal_components,
-        jsonify_fn=jsonify,
-        logger=logger,
-        pd_module=pd,
-        np_module=np,
     )
     return response
 
@@ -1530,8 +1476,6 @@ def _record_portfolio_snapshot_legacy(portfolio_data, user_id):
         portfolio_data,
         user_id,
         get_db_fn=get_db,
-        logger=logger,
-        datetime_cls=datetime,
     )
 
 
@@ -1550,10 +1494,7 @@ def get_paper_portfolio():
     return paper_handlers.get_paper_portfolio_handler(
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
-        jsonify_fn=jsonify,
         yf_module=yf,
-        pd_module=pd,
-        logger=logger,
     )
 
 
@@ -1567,7 +1508,6 @@ def optimize_paper_portfolio():
         load_portfolio_fn=load_portfolio,
         optimize_portfolio_fn=portfolio_optimization_service.optimize_paper_portfolio,
         error_cls=portfolio_optimization_service.PortfolioOptimizationError,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1581,11 +1521,8 @@ def buy_stock():
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
         save_portfolio_with_snapshot_fn=save_portfolio_with_snapshot,
-        jsonify_fn=jsonify,
         yf_module=yf,
         log_api_error_fn=log_api_error,
-        logger=logger,
-        datetime_cls=datetime,
     )
 
 
@@ -1599,11 +1536,8 @@ def sell_stock():
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
         save_portfolio_with_snapshot_fn=save_portfolio_with_snapshot,
-        jsonify_fn=jsonify,
         yf_module=yf,
         log_api_error_fn=log_api_error,
-        logger=logger,
-        datetime_cls=datetime,
     )
 
 
@@ -1615,8 +1549,6 @@ def buy_option():
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
         save_portfolio_with_snapshot_fn=save_portfolio_with_snapshot,
-        jsonify_fn=jsonify,
-        datetime_cls=datetime,
     )
 
 
@@ -1628,8 +1560,6 @@ def sell_option():
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
         save_portfolio_with_snapshot_fn=save_portfolio_with_snapshot,
-        jsonify_fn=jsonify,
-        datetime_cls=datetime,
     )
 
 
@@ -1641,12 +1571,7 @@ def get_paper_history():
         request_obj=request,
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
-        jsonify_fn=jsonify,
         yf_module=yf,
-        pd_module=pd,
-        np_module=np,
-        logger=logger,
-        datetime_cls=datetime,
         date_cls=date,
         timedelta_cls=timedelta,
     )
@@ -1658,7 +1583,6 @@ def get_trade_history():
     return paper_handlers.get_trade_history_handler(
         get_current_user_id_fn=get_current_user_id,
         load_portfolio_fn=load_portfolio,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1668,7 +1592,6 @@ def reset_portfolio():
     return paper_handlers.reset_portfolio_handler(
         get_current_user_id_fn=get_current_user_id,
         save_portfolio_with_snapshot_fn=save_portfolio_with_snapshot,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1681,10 +1604,7 @@ def handle_notifications():
         get_current_user_id_fn=get_current_user_id,
         load_notifications_fn=load_notifications,
         save_notifications_fn=save_notifications,
-        jsonify_fn=jsonify,
         yf_module=yf,
-        uuid_module=uuid,
-        datetime_cls=datetime,
     )
 
 
@@ -1696,12 +1616,7 @@ def create_smart_alert():
         get_current_user_id_fn=get_current_user_id,
         load_notifications_fn=load_notifications,
         save_notifications_fn=save_notifications,
-        jsonify_fn=jsonify,
         yf_module=yf,
-        uuid_module=uuid,
-        datetime_cls=datetime,
-        logger=logger,
-        re_module=re,
     )
 
 
@@ -1713,7 +1628,6 @@ def delete_notification(alert_id):
         get_current_user_id_fn=get_current_user_id,
         load_notifications_fn=load_notifications,
         save_notifications_fn=save_notifications,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1725,7 +1639,6 @@ def get_triggered_notifications():
         get_current_user_id_fn=get_current_user_id,
         load_notifications_fn=load_notifications,
         save_notifications_fn=save_notifications,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1737,7 +1650,6 @@ def delete_triggered_notification(alert_id):
         get_current_user_id_fn=get_current_user_id,
         load_notifications_fn=load_notifications,
         save_notifications_fn=save_notifications,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1751,9 +1663,6 @@ def _check_alerts_for_user(user_id):
         load_notifications_fn=load_notifications,
         save_notifications_fn=save_notifications,
         yf_module=yf,
-        logger=logger,
-        uuid_module=uuid,
-        datetime_cls=datetime,
     )
 
 
@@ -1761,7 +1670,6 @@ def check_alerts():
     return api_scheduler_helpers.check_alerts(
         iter_user_ids_fn=_iter_user_ids,
         check_alerts_for_user_fn=_check_alerts_for_user,
-        logger=logger,
     )
 
 
@@ -1769,7 +1677,6 @@ def run_scheduler():
     return api_scheduler_helpers.run_scheduler(
         schedule_module=schedule,
         check_alerts_fn=check_alerts,
-        time_module=time,
     )
 
 
@@ -1781,7 +1688,6 @@ def run_scheduler():
 def news_api():
     return reference_data_handlers.news_api_handler(
         get_general_news_fn=get_general_news,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1792,8 +1698,6 @@ def evaluate_models(ticker):
         ticker,
         request_obj=request,
         rolling_window_backtest_fn=rolling_window_backtest,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1802,8 +1706,6 @@ def forex_convert():
     return reference_data_handlers.forex_convert_handler(
         request_obj=request,
         get_exchange_rate_fn=get_exchange_rate,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1811,8 +1713,6 @@ def forex_convert():
 def forex_currencies():
     return reference_data_handlers.forex_currencies_handler(
         get_currency_list_fn=get_currency_list,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1821,8 +1721,6 @@ def crypto_convert():
     return reference_data_handlers.crypto_convert_handler(
         request_obj=request,
         get_crypto_exchange_rate_fn=get_crypto_exchange_rate,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1830,8 +1728,6 @@ def crypto_convert():
 def crypto_list():
     return reference_data_handlers.crypto_list_handler(
         get_crypto_list_fn=get_crypto_list,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1839,8 +1735,6 @@ def crypto_list():
 def crypto_target_currencies():
     return reference_data_handlers.crypto_target_currencies_handler(
         get_target_currencies_fn=get_target_currencies,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1850,8 +1744,6 @@ def commodity_price(commodity):
         commodity,
         request_obj=request,
         get_commodity_price_fn=get_commodity_price,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1859,8 +1751,6 @@ def commodity_price(commodity):
 def commodities_list():
     return reference_data_handlers.commodities_list_handler(
         get_commodity_list_fn=get_commodity_list,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1868,8 +1758,6 @@ def commodities_list():
 def commodities_all():
     return reference_data_handlers.commodities_all_handler(
         get_commodities_by_category_fn=get_commodities_by_category,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -1884,9 +1772,7 @@ def list_prediction_markets():
         request_obj=request,
         pm_search_markets_fn=pm_search_markets,
         pm_fetch_markets_fn=pm_fetch_markets,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
     )
 
 
@@ -1895,7 +1781,6 @@ def list_prediction_markets():
 def list_prediction_exchanges():
     return prediction_markets_handlers.list_prediction_exchanges_handler(
         pm_get_exchanges_fn=pm_get_exchanges,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1907,9 +1792,7 @@ def analyze_prediction_market():
         request_obj=request,
         analyze_prediction_market_fn=pm_analyze_market,
         error_cls=PredictionMarketAnalysisError,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
     )
 
 
@@ -1920,9 +1803,7 @@ def get_prediction_market(market_id):
         market_id,
         request_obj=request,
         pm_get_market_fn=pm_get_market,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
     )
 
 
@@ -1934,9 +1815,7 @@ def get_prediction_portfolio():
         get_current_user_id_fn=get_current_user_id,
         load_prediction_portfolio_fn=load_prediction_portfolio,
         pm_get_prices_fn=pm_get_prices,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
     )
 
 
@@ -1951,10 +1830,7 @@ def buy_prediction_contract():
         load_prediction_portfolio_fn=load_prediction_portfolio,
         pm_get_market_fn=pm_get_market,
         save_prediction_portfolio_fn=save_prediction_portfolio,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
-        datetime_cls=datetime,
     )
 
 
@@ -1969,10 +1845,7 @@ def sell_prediction_contract():
         load_prediction_portfolio_fn=load_prediction_portfolio,
         pm_get_market_fn=pm_get_market,
         save_prediction_portfolio_fn=save_prediction_portfolio,
-        jsonify_fn=jsonify,
         log_api_error_fn=log_api_error,
-        logger=logger,
-        datetime_cls=datetime,
     )
 
 
@@ -1983,7 +1856,6 @@ def get_prediction_trade_history():
     return prediction_markets_handlers.get_prediction_trade_history_handler(
         get_current_user_id_fn=get_current_user_id,
         load_prediction_portfolio_fn=load_prediction_portfolio,
-        jsonify_fn=jsonify,
     )
 
 
@@ -1994,7 +1866,6 @@ def reset_prediction_portfolio():
     return prediction_markets_handlers.reset_prediction_portfolio_handler(
         get_current_user_id_fn=get_current_user_id,
         save_prediction_portfolio_fn=save_prediction_portfolio,
-        jsonify_fn=jsonify,
     )
 
 
@@ -2012,9 +1883,6 @@ def get_fundamentals(ticker):
         ticker,
         request_obj=request,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        requests_module=requests,
-        jsonify_fn=jsonify,
-        logger=logger,
         clean_value_fn=clean_value,
         fundamentals_from_yfinance_fn=_fundamentals_from_yfinance,
         resolve_asset_fn=_resolve_market_asset,
@@ -2028,8 +1896,6 @@ def search_symbols():
         request_obj=request,
         get_symbol_suggestions_fn=get_symbol_suggestions,
         search_international_symbols_fn=akshare_service.search_equities,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -2045,10 +1911,6 @@ CALENDAR_CACHE = {
 def get_economic_calendar():
     return reference_data_handlers.get_economic_calendar_handler(
         calendar_cache=CALENDAR_CACHE,
-        requests_module=requests,
-        jsonify_fn=jsonify,
-        time_module=time,
-        datetime_cls=datetime,
     )
 
 
@@ -2056,8 +1918,6 @@ def get_economic_calendar():
 def get_market_sessions_calendar():
     return reference_data_handlers.get_market_sessions_handler(
         request_obj=request,
-        jsonify_fn=jsonify,
-        logger=logger,
         exchange_session_service_module=exchange_session_service,
     )
 
@@ -2075,8 +1935,6 @@ def get_financial_statements(ticker):
         ticker,
         openbb_available=OPENBB_AVAILABLE,
         obb_module=obb if OPENBB_AVAILABLE else None,
-        jsonify_fn=jsonify,
-        logger=logger,
         obb_to_float_fn=_obb_to_float,
     )
 
@@ -2088,8 +1946,6 @@ def get_sec_filings(ticker):
         openbb_available=OPENBB_AVAILABLE,
         obb_module=obb if OPENBB_AVAILABLE else None,
         sec_filings_service_module=sec_filings_service,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -2098,8 +1954,6 @@ def get_sec_intelligence(ticker):
     return reference_data_handlers.get_sec_intelligence_handler(
         ticker,
         sec_filings_service_module=sec_filings_service,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -2109,8 +1963,6 @@ def get_sec_filing_detail(ticker, accession_number):
         ticker,
         accession_number,
         sec_filings_service_module=sec_filings_service,
-        jsonify_fn=jsonify,
-        logger=logger,
     )
 
 
@@ -2119,8 +1971,6 @@ def get_screener():
     return reference_data_handlers.get_screener_handler(
         base_dir=BASE_DIR,
         yf_module=yf,
-        jsonify_fn=jsonify,
-        logger=logger,
         screener_query_service_module=screener_query_service,
     )
 
@@ -2130,8 +1980,6 @@ def get_screener_presets():
     return reference_data_handlers.get_screener_presets_handler(
         base_dir=BASE_DIR,
         yf_module=yf,
-        jsonify_fn=jsonify,
-        logger=logger,
         screener_query_service_module=screener_query_service,
     )
 
@@ -2142,8 +1990,6 @@ def get_screener_scan():
         base_dir=BASE_DIR,
         yf_module=yf,
         request_obj=request,
-        jsonify_fn=jsonify,
-        logger=logger,
         screener_query_service_module=screener_query_service,
     )
 
@@ -2159,11 +2005,8 @@ def get_macro_overview():
     return reference_data_handlers.get_macro_overview_handler(
         openbb_available=OPENBB_AVAILABLE,
         obb_module=obb if OPENBB_AVAILABLE else None,
-        jsonify_fn=jsonify,
-        logger=logger,
         yf_module=yf,
         macro_indicators=MACRO_INDICATORS,
-        requests_module=requests,
         request_obj=request,
         akshare_service_module=akshare_service,
     )
@@ -2224,8 +2067,6 @@ def public_api_stock(ticker):
         get_stock_data_handler_fn=market_data_handlers.get_stock_data_handler,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         yf_module=yf,
-        requests_module=requests,
-        logger=logger,
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
@@ -2249,7 +2090,6 @@ def public_api_chart(ticker):
         cache_ttl_seconds=60,
         get_chart_data_handler_fn=market_data_handlers.get_chart_data_handler,
         yf_module=yf,
-        logger=logger,
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
@@ -2272,7 +2112,6 @@ def public_api_news():
         get_query_news_handler_fn=market_data_handlers.get_query_news_handler,
         get_general_news_fn=get_general_news,
         news_api_key=NEWS_API_KEY,
-        requests_module=requests,
     )
 
 
@@ -2292,7 +2131,6 @@ def public_api_search_symbols():
         search_symbols_handler_fn=market_data_handlers.search_symbols_handler,
         get_symbol_suggestions_fn=get_symbol_suggestions,
         search_international_symbols_fn=lambda _query, market='us': [] if market != 'all' else [],
-        logger=logger,
     )
 
 
@@ -2314,9 +2152,6 @@ def public_api_ensemble_prediction(ticker):
         future_prediction_dates_fn=prediction_service.get_future_prediction_dates,
         yf_module=yf,
         live_ensemble_signal_components_fn=_live_ensemble_signal_components,
-        logger=logger,
-        pd_module=pd,
-        np_module=np,
     )
 
 
@@ -2336,8 +2171,6 @@ def public_api_fundamentals(ticker):
         cache_ttl_seconds=3600,
         get_fundamentals_handler_fn=reference_data_handlers.get_fundamentals_handler,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        requests_module=requests,
-        logger=logger,
         clean_value_fn=clean_value,
         fundamentals_from_yfinance_fn=_fundamentals_from_yfinance,
         resolve_asset_fn=_resolve_market_asset,
@@ -2361,10 +2194,8 @@ def public_api_macro_overview():
         get_macro_overview_handler_fn=reference_data_handlers.get_macro_overview_handler,
         openbb_available=OPENBB_AVAILABLE,
         obb_module=obb if OPENBB_AVAILABLE else None,
-        logger=logger,
         yf_module=yf,
         macro_indicators=MACRO_INDICATORS,
-        requests_module=requests,
     )
 
 
@@ -2394,7 +2225,6 @@ def public_api_v2_search_symbols():
         search_symbols_handler_fn=market_data_handlers.search_symbols_handler,
         get_symbol_suggestions_fn=get_symbol_suggestions,
         search_international_symbols_fn=akshare_service.search_equities,
-        logger=logger,
     )
 
 
@@ -2415,8 +2245,6 @@ def public_api_v2_stock(ticker):
         get_stock_data_handler_fn=market_data_handlers.get_stock_data_handler,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         yf_module=yf,
-        requests_module=requests,
-        logger=logger,
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
@@ -2440,7 +2268,6 @@ def public_api_v2_chart(ticker):
         cache_ttl_seconds=60,
         get_chart_data_handler_fn=market_data_handlers.get_chart_data_handler,
         yf_module=yf,
-        logger=logger,
         clean_value_fn=clean_value,
         resolve_asset_fn=_resolve_market_asset,
         akshare_service_module=akshare_service,
@@ -2463,8 +2290,6 @@ def public_api_v2_fundamentals(ticker):
         cache_ttl_seconds=3600,
         get_fundamentals_handler_fn=reference_data_handlers.get_fundamentals_handler,
         alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        requests_module=requests,
-        logger=logger,
         clean_value_fn=clean_value,
         fundamentals_from_yfinance_fn=_fundamentals_from_yfinance,
         resolve_asset_fn=_resolve_market_asset,
@@ -2489,10 +2314,8 @@ def public_api_v2_macro_overview():
         get_macro_overview_handler_fn=reference_data_handlers.get_macro_overview_handler,
         openbb_available=OPENBB_AVAILABLE,
         obb_module=obb if OPENBB_AVAILABLE else None,
-        logger=logger,
         yf_module=yf,
         macro_indicators=MACRO_INDICATORS,
-        requests_module=requests,
         akshare_service_module=akshare_service,
     )
 
@@ -2515,9 +2338,6 @@ def public_api_v2_ensemble_prediction(ticker):
         future_prediction_dates_fn=prediction_service.get_future_prediction_dates,
         yf_module=yf,
         live_ensemble_signal_components_fn=_live_ensemble_signal_components,
-        logger=logger,
-        pd_module=pd,
-        np_module=np,
     )
 
 
@@ -2537,7 +2357,6 @@ def public_api_v2_evaluations(ticker):
         cache_ttl_seconds=900,
         evaluate_models_handler_fn=market_data_handlers.evaluate_models_handler,
         rolling_window_backtest_fn=rolling_window_backtest,
-        logger=logger,
     )
 
 
@@ -2556,7 +2375,6 @@ def public_api_v2_screener_presets():
         get_screener_presets_handler_fn=reference_data_handlers.get_screener_presets_handler,
         base_dir=BASE_DIR,
         yf_module=yf,
-        logger=logger,
         screener_query_service_module=screener_query_service,
     )
 
@@ -2577,7 +2395,6 @@ def public_api_v2_screener_scan():
         get_screener_scan_handler_fn=reference_data_handlers.get_screener_scan_handler,
         base_dir=BASE_DIR,
         yf_module=yf,
-        logger=logger,
         screener_query_service_module=screener_query_service,
     )
 
@@ -2635,8 +2452,6 @@ def public_api_v2_option_chain(ticker):
         cache_ttl_seconds=60,
         get_option_chain_handler_fn=market_data_handlers.get_option_chain_handler,
         yf_module=yf,
-        math_module=math,
-        logger=logger,
     )
 
 
@@ -2655,7 +2470,6 @@ def public_api_v2_option_suggestion(ticker):
         cache_ttl_seconds=900,
         get_option_suggestion_handler_fn=market_data_handlers.get_option_suggestion_handler,
         generate_suggestion_fn=generate_suggestion,
-        logger=logger,
     )
 
 
@@ -2674,7 +2488,6 @@ def public_api_v2_forex_convert():
         cache_ttl_seconds=300,
         forex_convert_handler_fn=reference_data_handlers.forex_convert_handler,
         get_exchange_rate_fn=get_exchange_rate,
-        logger=logger,
     )
 
 
@@ -2692,7 +2505,6 @@ def public_api_v2_forex_currencies():
         cache_ttl_seconds=86400,
         forex_currencies_handler_fn=reference_data_handlers.forex_currencies_handler,
         get_currency_list_fn=get_currency_list,
-        logger=logger,
     )
 
 
@@ -2711,7 +2523,6 @@ def public_api_v2_crypto_convert():
         cache_ttl_seconds=300,
         crypto_convert_handler_fn=reference_data_handlers.crypto_convert_handler,
         get_crypto_exchange_rate_fn=get_crypto_exchange_rate,
-        logger=logger,
     )
 
 
@@ -2729,7 +2540,6 @@ def public_api_v2_crypto_list():
         cache_ttl_seconds=86400,
         crypto_list_handler_fn=reference_data_handlers.crypto_list_handler,
         get_crypto_list_fn=get_crypto_list,
-        logger=logger,
     )
 
 
@@ -2747,7 +2557,6 @@ def public_api_v2_crypto_currencies():
         cache_ttl_seconds=86400,
         crypto_target_currencies_handler_fn=reference_data_handlers.crypto_target_currencies_handler,
         get_target_currencies_fn=get_target_currencies,
-        logger=logger,
     )
 
 
@@ -2767,7 +2576,6 @@ def public_api_v2_commodity_price(commodity):
         cache_ttl_seconds=300,
         commodity_price_handler_fn=reference_data_handlers.commodity_price_handler,
         get_commodity_price_fn=get_commodity_price,
-        logger=logger,
     )
 
 
@@ -2785,7 +2593,6 @@ def public_api_v2_commodities_list():
         cache_ttl_seconds=86400,
         commodities_list_handler_fn=reference_data_handlers.commodities_list_handler,
         get_commodity_list_fn=get_commodity_list,
-        logger=logger,
     )
 
 
@@ -2803,7 +2610,6 @@ def public_api_v2_commodities_all():
         cache_ttl_seconds=86400,
         commodities_all_handler_fn=reference_data_handlers.commodities_all_handler,
         get_commodities_by_category_fn=get_commodities_by_category,
-        logger=logger,
     )
 
 
@@ -2824,7 +2630,6 @@ def public_api_v2_prediction_markets():
         pm_search_markets_fn=pm_search_markets,
         pm_fetch_markets_fn=pm_fetch_markets,
         log_api_error_fn=log_api_error,
-        logger=logger,
     )
 
 
@@ -2862,7 +2667,6 @@ def public_api_v2_prediction_market_detail(market_id):
         get_prediction_market_handler_fn=prediction_markets_handlers.get_prediction_market_handler,
         pm_get_market_fn=pm_get_market,
         log_api_error_fn=log_api_error,
-        logger=logger,
     )
 
 
@@ -2880,9 +2684,6 @@ def public_api_v2_calendar_economic():
         cache_ttl_seconds=900,
         get_economic_calendar_handler_fn=reference_data_handlers.get_economic_calendar_handler,
         calendar_cache=CALENDAR_CACHE,
-        requests_module=requests,
-        time_module=time,
-        datetime_cls=datetime,
     )
 
 

--- a/backend/api_auth.py
+++ b/backend/api_auth.py
@@ -193,7 +193,7 @@ def build_require_auth(
     token_getter,
     verify_token_fn,
     sync_authenticated_user_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
     unauthorized_response_fn,
     set_request_identity_fn,
 ):

--- a/backend/api_handlers_deliverables.py
+++ b/backend/api_handlers_deliverables.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from flask import jsonify
+
 
 def list_deliverables_handler(
     *,
@@ -10,7 +12,7 @@ def list_deliverables_handler(
     database_url,
     list_deliverables_fn,
     get_current_user_id_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -32,7 +34,7 @@ def create_deliverable_handler(
     create_deliverable_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -58,7 +60,7 @@ def get_deliverable_handler(
     get_deliverable_detail_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -85,7 +87,7 @@ def patch_deliverable_handler(
     update_deliverable_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -112,7 +114,7 @@ def put_deliverable_assumptions_handler(
     replace_deliverable_assumptions_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -145,7 +147,7 @@ def post_deliverable_review_handler(
     add_deliverable_review_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -171,7 +173,7 @@ def post_deliverable_preflight_handler(
     create_deliverable_preflight_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -197,7 +199,7 @@ def get_deliverable_context_handler(
     build_deliverable_context_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -223,7 +225,7 @@ def get_deliverable_memos_handler(
     list_deliverable_memos_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -249,7 +251,7 @@ def post_deliverable_generate_handler(
     generate_deliverable_memo_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -279,7 +281,7 @@ def download_deliverable_memo_handler(
     get_deliverable_memo_artifact_fn,
     get_current_user_id_fn,
     deliverable_error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     bytes_io_cls,
     send_file_fn,
     docx_mime_type,

--- a/backend/api_handlers_market_data.py
+++ b/backend/api_handlers_market_data.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+import math
+
+from flask import jsonify
+import yfinance as yf
+import pandas as pd
+import numpy as np
+import requests
+import logging
+
 import sentiment_service
 
 
-def get_watchlist_handler(*, get_current_user_id_fn, load_watchlist_fn, jsonify_fn):
+def get_watchlist_handler(*, get_current_user_id_fn, load_watchlist_fn, jsonify_fn=jsonify):
     return jsonify_fn(load_watchlist_fn(get_current_user_id_fn()))
 
 
@@ -13,7 +22,7 @@ def add_to_watchlist_handler(
     get_current_user_id_fn,
     load_watchlist_fn,
     save_watchlist_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     user_id = get_current_user_id_fn()
     current_watchlist = load_watchlist_fn(user_id)
@@ -30,7 +39,7 @@ def remove_from_watchlist_handler(
     get_current_user_id_fn,
     load_watchlist_fn,
     save_watchlist_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     user_id = get_current_user_id_fn()
     normalized_ticker = ticker.upper()
@@ -44,10 +53,10 @@ def get_stock_data_handler(
     *,
     request_obj,
     alpha_vantage_api_key,
-    yf_module,
-    requests_module,
-    jsonify_fn,
-    logger,
+    yf_module=yf,
+    requests_module=requests,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
@@ -189,9 +198,9 @@ def get_chart_data_handler(
     ticker,
     *,
     request_obj,
-    yf_module,
-    jsonify_fn,
-    logger,
+    yf_module=yf,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     chart_prediction_points_fn,
     resolve_asset_fn,
@@ -246,7 +255,7 @@ def get_chart_data_handler(
         return jsonify_fn({"error": f"An error occurred while fetching chart data: {str(exc)}"}), 500
 
 
-def get_query_news_handler(*, request_obj, news_api_key, requests_module, jsonify_fn):
+def get_query_news_handler(*, request_obj, news_api_key, requests_module=requests, jsonify_fn=jsonify):
     query = request_obj.args.get("q")
     if not query:
         return jsonify_fn({"error": "A search query ('q') is required."}), 400
@@ -279,7 +288,7 @@ def get_query_news_handler(*, request_obj, news_api_key, requests_module, jsonif
         return jsonify_fn({"error": f"An error occurred while fetching news: {str(exc)}"}), 500
 
 
-def get_options_stock_price_handler(ticker, *, yf_module, jsonify_fn, clean_value_fn):
+def get_options_stock_price_handler(ticker, *, yf_module=yf, jsonify_fn=jsonify, clean_value_fn):
     try:
         sanitized_ticker = ticker.split(":")[0]
         stock = yf_module.Ticker(sanitized_ticker)
@@ -292,7 +301,7 @@ def get_options_stock_price_handler(ticker, *, yf_module, jsonify_fn, clean_valu
         return jsonify_fn({"error": str(exc)}), 500
 
 
-def get_option_expirations_handler(ticker, *, yf_module, jsonify_fn):
+def get_option_expirations_handler(ticker, *, yf_module=yf, jsonify_fn=jsonify):
     try:
         sanitized_ticker = ticker.split(":")[0]
         stock = yf_module.Ticker(sanitized_ticker)
@@ -304,7 +313,7 @@ def get_option_expirations_handler(ticker, *, yf_module, jsonify_fn):
         return jsonify_fn({"error": str(exc)}), 500
 
 
-def get_option_chain_handler(ticker, *, request_obj, yf_module, jsonify_fn, math_module, logger):
+def get_option_chain_handler(ticker, *, request_obj, yf_module=yf, jsonify_fn=jsonify, math_module=math, logger=logging.getLogger("marketmind_api")):
     try:
         option_date = request_obj.args.get("date")
         stock = yf_module.Ticker(ticker)
@@ -352,7 +361,7 @@ def get_option_chain_handler(ticker, *, request_obj, yf_module, jsonify_fn, math
         return jsonify_fn({"error": str(exc)}), 500
 
 
-def get_option_suggestion_handler(ticker, *, generate_suggestion_fn, jsonify_fn, logger):
+def get_option_suggestion_handler(ticker, *, generate_suggestion_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         sanitized_ticker = ticker.split(":")[0].upper()
         suggestion = generate_suggestion_fn(sanitized_ticker)
@@ -380,11 +389,11 @@ def predict_stock_handler(
     lstm_predict_fn=None,
     transformer_train_fn=None,
     transformer_predict_fn=None,
-    yf_module,
-    jsonify_fn,
+    yf_module=yf,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
-    pd_module,
+    logger=logging.getLogger("marketmind_api"),
+    pd_module=pd,
 ):
     try:
         sanitized_ticker = ticker.split(":")[0]
@@ -465,12 +474,12 @@ def predict_ensemble_handler(
     *,
     request_obj,
     future_prediction_dates_fn,
-    yf_module,
+    yf_module=yf,
     live_ensemble_signal_components_fn,
-    jsonify_fn,
-    logger,
-    pd_module,
-    np_module,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
+    pd_module=pd,
+    np_module=np,
 ):
     try:
         sanitized_ticker = ticker.split(":")[0]
@@ -525,8 +534,8 @@ def evaluate_models_handler(
     *,
     request_obj,
     rolling_window_backtest_fn,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
 ):
     try:
         sanitized_ticker = ticker.split(":")[0]
@@ -562,8 +571,8 @@ def search_symbols_handler(
     request_obj,
     get_symbol_suggestions_fn,
     search_international_symbols_fn,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
 ):
     query = request_obj.args.get("q")
     if not query:

--- a/backend/api_handlers_marketmind_ai.py
+++ b/backend/api_handlers_marketmind_ai.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from flask import jsonify
+
 
 def get_bootstrap_handler(
     *,
     deliverables_ready_fn,
     not_configured_response_fn,
     get_bootstrap_payload_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -22,7 +24,7 @@ def list_chats_handler(
     database_url,
     list_chats_fn,
     get_current_user_id_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -44,7 +46,7 @@ def get_chat_handler(
     get_chat_detail_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -70,7 +72,7 @@ def delete_chat_handler(
     delete_chat_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -97,7 +99,7 @@ def get_context_handler(
     build_context_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -124,7 +126,7 @@ def get_retrieval_status_handler(
     get_retrieval_status_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -155,7 +157,7 @@ def post_chat_handler(
     generate_reply_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -188,7 +190,7 @@ def post_artifact_preflight_handler(
     create_artifact_preflight_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -218,7 +220,7 @@ def list_artifacts_handler(
     database_url,
     list_artifacts_fn,
     get_current_user_id_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -240,7 +242,7 @@ def generate_artifact_handler(
     generate_artifact_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -269,7 +271,7 @@ def get_artifact_handler(
     get_artifact_detail_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     if not deliverables_ready_fn():
         return not_configured_response_fn()
@@ -296,7 +298,7 @@ def download_artifact_handler(
     get_artifact_download_fn,
     get_current_user_id_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     bytes_io_cls,
     send_file_fn,
     docx_mime_type,

--- a/backend/api_handlers_notifications.py
+++ b/backend/api_handlers_notifications.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from flask import jsonify
+import yfinance as yf
+import uuid
+from datetime import datetime
+import re
+import logging
+
 
 def handle_notifications_handler(
     *,
@@ -7,10 +14,10 @@ def handle_notifications_handler(
     get_current_user_id_fn,
     load_notifications_fn,
     save_notifications_fn,
-    jsonify_fn,
-    yf_module,
-    uuid_module,
-    datetime_cls,
+    jsonify_fn=jsonify,
+    yf_module=yf,
+    uuid_module=uuid,
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     notifications = load_notifications_fn(user_id)
@@ -50,12 +57,12 @@ def create_smart_alert_handler(
     get_current_user_id_fn,
     load_notifications_fn,
     save_notifications_fn,
-    jsonify_fn,
-    yf_module,
-    uuid_module,
-    datetime_cls,
-    logger,
-    re_module,
+    jsonify_fn=jsonify,
+    yf_module=yf,
+    uuid_module=uuid,
+    datetime_cls=datetime,
+    logger=logging.getLogger("marketmind_api"),
+    re_module=re,
 ):
     try:
         user_id = get_current_user_id_fn()
@@ -166,7 +173,7 @@ def delete_notification_handler(
     get_current_user_id_fn,
     load_notifications_fn,
     save_notifications_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     user_id = get_current_user_id_fn()
     notifications = load_notifications_fn(user_id)
@@ -181,7 +188,7 @@ def get_triggered_notifications_handler(
     get_current_user_id_fn,
     load_notifications_fn,
     save_notifications_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     user_id = get_current_user_id_fn()
     notifications = load_notifications_fn(user_id)
@@ -211,7 +218,7 @@ def delete_triggered_notification_handler(
     get_current_user_id_fn,
     load_notifications_fn,
     save_notifications_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     user_id = get_current_user_id_fn()
     notifications = load_notifications_fn(user_id)

--- a/backend/api_handlers_paper.py
+++ b/backend/api_handlers_paper.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from flask import jsonify
+import yfinance as yf
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import logging
+
 
 def optimize_paper_portfolio_handler(
     *,
@@ -8,7 +15,7 @@ def optimize_paper_portfolio_handler(
     load_portfolio_fn,
     optimize_portfolio_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_portfolio_fn(user_id)
@@ -30,10 +37,10 @@ def get_paper_portfolio_handler(
     *,
     get_current_user_id_fn,
     load_portfolio_fn,
-    jsonify_fn,
-    yf_module,
-    pd_module,
-    logger,
+    jsonify_fn=jsonify,
+    yf_module=yf,
+    pd_module=pd,
+    logger=logging.getLogger("marketmind_api"),
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_portfolio_fn(user_id)
@@ -180,11 +187,11 @@ def buy_stock_handler(
     get_current_user_id_fn,
     load_portfolio_fn,
     save_portfolio_with_snapshot_fn,
-    jsonify_fn,
-    yf_module,
+    jsonify_fn=jsonify,
+    yf_module=yf,
     log_api_error_fn,
-    logger,
-    datetime_cls,
+    logger=logging.getLogger("marketmind_api"),
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_portfolio_fn(user_id)
@@ -239,11 +246,11 @@ def sell_stock_handler(
     get_current_user_id_fn,
     load_portfolio_fn,
     save_portfolio_with_snapshot_fn,
-    jsonify_fn,
-    yf_module,
+    jsonify_fn=jsonify,
+    yf_module=yf,
     log_api_error_fn,
-    logger,
-    datetime_cls,
+    logger=logging.getLogger("marketmind_api"),
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_portfolio_fn(user_id)
@@ -300,8 +307,8 @@ def buy_option_handler(
     get_current_user_id_fn,
     load_portfolio_fn,
     save_portfolio_with_snapshot_fn,
-    jsonify_fn,
-    datetime_cls,
+    jsonify_fn=jsonify,
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_portfolio_fn(user_id)
@@ -343,8 +350,8 @@ def sell_option_handler(
     get_current_user_id_fn,
     load_portfolio_fn,
     save_portfolio_with_snapshot_fn,
-    jsonify_fn,
-    datetime_cls,
+    jsonify_fn=jsonify,
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_portfolio_fn(user_id)
@@ -387,12 +394,12 @@ def get_paper_history_handler(
     request_obj,
     get_current_user_id_fn,
     load_portfolio_fn,
-    jsonify_fn,
-    yf_module,
-    pd_module,
-    np_module,
-    logger,
-    datetime_cls,
+    jsonify_fn=jsonify,
+    yf_module=yf,
+    pd_module=pd,
+    np_module=np,
+    logger=logging.getLogger("marketmind_api"),
+    datetime_cls=datetime,
     date_cls,
     timedelta_cls,
 ):
@@ -538,12 +545,12 @@ def get_paper_history_handler(
         return jsonify_fn({'error': f'Failed to build history: {str(exc)}'}), 500
 
 
-def get_trade_history_handler(*, get_current_user_id_fn, load_portfolio_fn, jsonify_fn):
+def get_trade_history_handler(*, get_current_user_id_fn, load_portfolio_fn, jsonify_fn=jsonify):
     portfolio = load_portfolio_fn(get_current_user_id_fn())
     return jsonify_fn(portfolio.get('trade_history', [])[-50:])
 
 
-def reset_portfolio_handler(*, get_current_user_id_fn, save_portfolio_with_snapshot_fn, jsonify_fn):
+def reset_portfolio_handler(*, get_current_user_id_fn, save_portfolio_with_snapshot_fn, jsonify_fn=jsonify):
     user_id = get_current_user_id_fn()
     new_portfolio = {
         'cash': 100000.0,

--- a/backend/api_handlers_prediction_markets.py
+++ b/backend/api_handlers_prediction_markets.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from flask import jsonify
+from datetime import datetime
+import logging
+
 
 def list_prediction_markets_handler(
     *,
     request_obj,
     pm_search_markets_fn,
     pm_fetch_markets_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     try:
         exchange = request_obj.args.get('exchange', 'polymarket')
@@ -33,7 +37,7 @@ def list_prediction_markets_handler(
         return jsonify_fn({"error": f"Failed to fetch prediction markets: {str(exc)}"}), 500
 
 
-def list_prediction_exchanges_handler(*, pm_get_exchanges_fn, jsonify_fn):
+def list_prediction_exchanges_handler(*, pm_get_exchanges_fn, jsonify_fn=jsonify):
     return jsonify_fn(pm_get_exchanges_fn())
 
 
@@ -42,9 +46,9 @@ def get_prediction_market_handler(
     *,
     request_obj,
     pm_get_market_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     try:
         exchange = request_obj.args.get('exchange', 'polymarket')
@@ -62,9 +66,9 @@ def analyze_prediction_market_handler(
     request_obj,
     analyze_prediction_market_fn,
     error_cls,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     try:
         if not request_obj.is_json:
@@ -94,9 +98,9 @@ def get_prediction_portfolio_handler(
     get_current_user_id_fn,
     load_prediction_portfolio_fn,
     pm_get_prices_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     try:
         user_id = get_current_user_id_fn()
@@ -164,10 +168,10 @@ def buy_prediction_contract_handler(
     load_prediction_portfolio_fn,
     pm_get_market_fn,
     save_prediction_portfolio_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
-    datetime_cls,
+    logger=logging.getLogger("marketmind_api"),
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_prediction_portfolio_fn(user_id)
@@ -246,10 +250,10 @@ def sell_prediction_contract_handler(
     load_prediction_portfolio_fn,
     pm_get_market_fn,
     save_prediction_portfolio_fn,
-    jsonify_fn,
+    jsonify_fn=jsonify,
     log_api_error_fn,
-    logger,
-    datetime_cls,
+    logger=logging.getLogger("marketmind_api"),
+    datetime_cls=datetime,
 ):
     user_id = get_current_user_id_fn()
     portfolio = load_prediction_portfolio_fn(user_id)
@@ -306,12 +310,12 @@ def sell_prediction_contract_handler(
         return jsonify_fn({"error": "Failed to execute sell order"}), 500
 
 
-def get_prediction_trade_history_handler(*, get_current_user_id_fn, load_prediction_portfolio_fn, jsonify_fn):
+def get_prediction_trade_history_handler(*, get_current_user_id_fn, load_prediction_portfolio_fn, jsonify_fn=jsonify):
     portfolio = load_prediction_portfolio_fn(get_current_user_id_fn())
     return jsonify_fn(portfolio.get('trade_history', [])[-50:])
 
 
-def reset_prediction_portfolio_handler(*, get_current_user_id_fn, save_prediction_portfolio_fn, jsonify_fn):
+def reset_prediction_portfolio_handler(*, get_current_user_id_fn, save_prediction_portfolio_fn, jsonify_fn=jsonify):
     user_id = get_current_user_id_fn()
     new_portfolio = {
         'cash': 10000.0,

--- a/backend/api_handlers_public.py
+++ b/backend/api_handlers_public.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+import yfinance as yf
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import math
+import time
+import requests
+import logging
+
 from types import SimpleNamespace
 from typing import Any
 
@@ -110,9 +119,9 @@ def stock_handler(
     cache_ttl_seconds: int,
     get_stock_data_handler_fn,
     alpha_vantage_api_key,
-    yf_module,
-    requests_module,
-    logger,
+    yf_module=yf,
+    requests_module=requests,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
@@ -168,9 +177,9 @@ def stock_handler_v2(
     cache_ttl_seconds: int,
     get_stock_data_handler_fn,
     alpha_vantage_api_key,
-    yf_module,
-    requests_module,
-    logger,
+    yf_module=yf,
+    requests_module=requests,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
@@ -231,8 +240,8 @@ def chart_handler(
     cache_key: str,
     cache_ttl_seconds: int,
     get_chart_data_handler_fn,
-    yf_module,
-    logger,
+    yf_module=yf,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
@@ -282,8 +291,8 @@ def chart_handler_v2(
     cache_key: str,
     cache_ttl_seconds: int,
     get_chart_data_handler_fn,
-    yf_module,
-    logger,
+    yf_module=yf,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     resolve_asset_fn,
     akshare_service_module,
@@ -338,7 +347,7 @@ def news_handler(
     get_query_news_handler_fn,
     get_general_news_fn,
     news_api_key,
-    requests_module,
+    requests_module=requests,
 ):
     def producer():
         query = str(request_obj.args.get("q", "")).strip()
@@ -383,7 +392,7 @@ def search_symbols_handler(
     search_symbols_handler_fn,
     get_symbol_suggestions_fn,
     search_international_symbols_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         query = str(request_obj.args.get("q", "")).strip()
@@ -419,7 +428,7 @@ def search_symbols_handler_v2(
     search_symbols_handler_fn,
     get_symbol_suggestions_fn,
     search_international_symbols_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         query = str(request_obj.args.get("q", "")).strip()
@@ -457,11 +466,11 @@ def ensemble_prediction_handler(
     cache_ttl_seconds: int,
     predict_ensemble_handler_fn,
     future_prediction_dates_fn,
-    yf_module,
+    yf_module=yf,
     live_ensemble_signal_components_fn,
-    logger,
-    pd_module,
-    np_module,
+    logger=logging.getLogger("marketmind_api"),
+    pd_module=pd,
+    np_module=np,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -524,7 +533,7 @@ def evaluation_summary_handler(
     cache_ttl_seconds: int,
     evaluate_models_handler_fn,
     rolling_window_backtest_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         safe_request = _public_request_subset(request_obj, allowed_args=("test_days", "fast_mode"))
@@ -590,8 +599,8 @@ def screener_presets_public_handler(
     cache_ttl_seconds: int,
     get_screener_presets_handler_fn,
     base_dir,
-    yf_module,
-    logger,
+    yf_module=yf,
+    logger=logging.getLogger("marketmind_api"),
     screener_query_service_module,
 ):
     def producer():
@@ -626,8 +635,8 @@ def screener_scan_public_handler(
     cache_ttl_seconds: int,
     get_screener_scan_handler_fn,
     base_dir,
-    yf_module,
-    logger,
+    yf_module=yf,
+    logger=logging.getLogger("marketmind_api"),
     screener_query_service_module,
 ):
     def producer():
@@ -664,8 +673,8 @@ def fundamentals_handler(
     cache_ttl_seconds: int,
     get_fundamentals_handler_fn,
     alpha_vantage_api_key,
-    requests_module,
-    logger,
+    requests_module=requests,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     fundamentals_from_yfinance_fn,
     resolve_asset_fn,
@@ -713,8 +722,8 @@ def fundamentals_handler_v2(
     cache_ttl_seconds: int,
     get_fundamentals_handler_fn,
     alpha_vantage_api_key,
-    requests_module,
-    logger,
+    requests_module=requests,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     fundamentals_from_yfinance_fn,
     resolve_asset_fn,
@@ -761,10 +770,10 @@ def macro_overview_handler(
     get_macro_overview_handler_fn,
     openbb_available,
     obb_module,
-    logger,
-    yf_module,
+    logger=logging.getLogger("marketmind_api"),
+    yf_module=yf,
     macro_indicators,
-    requests_module,
+    requests_module=requests,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -814,10 +823,10 @@ def macro_overview_handler_v2(
     get_macro_overview_handler_fn,
     openbb_available,
     obb_module,
-    logger,
-    yf_module,
+    logger=logging.getLogger("marketmind_api"),
+    yf_module=yf,
     macro_indicators,
-    requests_module,
+    requests_module=requests,
     akshare_service_module,
 ):
     def producer():
@@ -892,7 +901,7 @@ def options_stock_price_handler(
     cache_key: str,
     cache_ttl_seconds: int,
     get_options_stock_price_handler_fn,
-    yf_module,
+    yf_module=yf,
     clean_value_fn,
 ):
     def producer():
@@ -923,7 +932,7 @@ def option_expirations_handler(
     cache_key: str,
     cache_ttl_seconds: int,
     get_option_expirations_handler_fn,
-    yf_module,
+    yf_module=yf,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -955,9 +964,9 @@ def option_chain_handler(
     cache_key: str,
     cache_ttl_seconds: int,
     get_option_chain_handler_fn,
-    yf_module,
-    math_module,
-    logger,
+    yf_module=yf,
+    math_module=math,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -999,7 +1008,7 @@ def option_suggestion_handler(
     cache_ttl_seconds: int,
     get_option_suggestion_handler_fn,
     generate_suggestion_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1032,7 +1041,7 @@ def forex_convert_public_handler(
     cache_ttl_seconds: int,
     forex_convert_handler_fn,
     get_exchange_rate_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1064,7 +1073,7 @@ def forex_currencies_public_handler(
     cache_ttl_seconds: int,
     forex_currencies_handler_fn,
     get_currency_list_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1094,7 +1103,7 @@ def crypto_convert_public_handler(
     cache_ttl_seconds: int,
     crypto_convert_handler_fn,
     get_crypto_exchange_rate_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1126,7 +1135,7 @@ def crypto_list_public_handler(
     cache_ttl_seconds: int,
     crypto_list_handler_fn,
     get_crypto_list_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1155,7 +1164,7 @@ def crypto_currencies_public_handler(
     cache_ttl_seconds: int,
     crypto_target_currencies_handler_fn,
     get_target_currencies_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1186,7 +1195,7 @@ def commodity_price_public_handler(
     cache_ttl_seconds: int,
     commodity_price_handler_fn,
     get_commodity_price_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1219,7 +1228,7 @@ def commodities_list_public_handler(
     cache_ttl_seconds: int,
     commodities_list_handler_fn,
     get_commodity_list_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1248,7 +1257,7 @@ def commodities_all_public_handler(
     cache_ttl_seconds: int,
     commodities_all_handler_fn,
     get_commodities_by_category_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1280,7 +1289,7 @@ def prediction_markets_list_public_handler(
     pm_search_markets_fn,
     pm_fetch_markets_fn,
     log_api_error_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1344,7 +1353,7 @@ def prediction_market_detail_public_handler(
     get_prediction_market_handler_fn,
     pm_get_market_fn,
     log_api_error_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(
@@ -1378,9 +1387,9 @@ def economic_calendar_public_handler(
     cache_ttl_seconds: int,
     get_economic_calendar_handler_fn,
     calendar_cache,
-    requests_module,
-    time_module,
-    datetime_cls,
+    requests_module=requests,
+    time_module=time,
+    datetime_cls=datetime,
 ):
     def producer():
         raw_payload, status_code = unwrap_handler_result(

--- a/backend/api_handlers_reference_data.py
+++ b/backend/api_handlers_reference_data.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from flask import jsonify
+import yfinance as yf
+from datetime import datetime
+import time
+import requests
+import logging
+
 import csv
 from io import StringIO
 
@@ -7,14 +14,14 @@ from io import StringIO
 _OPENBB_MACRO_SUPPORT_CACHE = {}
 
 
-def news_api_handler(*, get_general_news_fn, jsonify_fn):
+def news_api_handler(*, get_general_news_fn, jsonify_fn=jsonify):
     try:
         return jsonify_fn(get_general_news_fn())
     except Exception as exc:
         return jsonify_fn({"error": f"Failed to fetch news: {str(exc)}"}), 500
 
 
-def forex_convert_handler(*, request_obj, get_exchange_rate_fn, jsonify_fn, logger):
+def forex_convert_handler(*, request_obj, get_exchange_rate_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         from_currency = request_obj.args.get("from", "USD").upper()
         to_currency = request_obj.args.get("to", "EUR").upper()
@@ -27,7 +34,7 @@ def forex_convert_handler(*, request_obj, get_exchange_rate_fn, jsonify_fn, logg
         return jsonify_fn({"error": f"Conversion failed: {str(exc)}"}), 500
 
 
-def forex_currencies_handler(*, get_currency_list_fn, jsonify_fn, logger):
+def forex_currencies_handler(*, get_currency_list_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         return jsonify_fn(get_currency_list_fn())
     except Exception as exc:
@@ -35,7 +42,7 @@ def forex_currencies_handler(*, get_currency_list_fn, jsonify_fn, logger):
         return jsonify_fn({"error": f"Failed to fetch currencies: {str(exc)}"}), 500
 
 
-def crypto_convert_handler(*, request_obj, get_crypto_exchange_rate_fn, jsonify_fn, logger):
+def crypto_convert_handler(*, request_obj, get_crypto_exchange_rate_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         from_crypto = request_obj.args.get("from", "BTC").upper()
         to_currency = request_obj.args.get("to", "USD").upper()
@@ -48,7 +55,7 @@ def crypto_convert_handler(*, request_obj, get_crypto_exchange_rate_fn, jsonify_
         return jsonify_fn({"error": f"Conversion failed: {str(exc)}"}), 500
 
 
-def crypto_list_handler(*, get_crypto_list_fn, jsonify_fn, logger):
+def crypto_list_handler(*, get_crypto_list_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         return jsonify_fn(get_crypto_list_fn())
     except Exception as exc:
@@ -56,7 +63,7 @@ def crypto_list_handler(*, get_crypto_list_fn, jsonify_fn, logger):
         return jsonify_fn({"error": f"Failed to fetch crypto list: {str(exc)}"}), 500
 
 
-def crypto_target_currencies_handler(*, get_target_currencies_fn, jsonify_fn, logger):
+def crypto_target_currencies_handler(*, get_target_currencies_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         return jsonify_fn(get_target_currencies_fn())
     except Exception as exc:
@@ -64,7 +71,7 @@ def crypto_target_currencies_handler(*, get_target_currencies_fn, jsonify_fn, lo
         return jsonify_fn({"error": f"Failed to fetch currencies: {str(exc)}"}), 500
 
 
-def commodity_price_handler(commodity, *, request_obj, get_commodity_price_fn, jsonify_fn, logger):
+def commodity_price_handler(commodity, *, request_obj, get_commodity_price_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         period = request_obj.args.get("period", "5d")
         data = get_commodity_price_fn(commodity, period)
@@ -76,7 +83,7 @@ def commodity_price_handler(commodity, *, request_obj, get_commodity_price_fn, j
         return jsonify_fn({"error": f"Failed to fetch commodity: {str(exc)}"}), 500
 
 
-def commodities_list_handler(*, get_commodity_list_fn, jsonify_fn, logger):
+def commodities_list_handler(*, get_commodity_list_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         return jsonify_fn(get_commodity_list_fn())
     except Exception as exc:
@@ -84,7 +91,7 @@ def commodities_list_handler(*, get_commodity_list_fn, jsonify_fn, logger):
         return jsonify_fn({"error": f"Failed to fetch commodities: {str(exc)}"}), 500
 
 
-def commodities_all_handler(*, get_commodities_by_category_fn, jsonify_fn, logger):
+def commodities_all_handler(*, get_commodities_by_category_fn, jsonify_fn=jsonify, logger=logging.getLogger("marketmind_api")):
     try:
         return jsonify_fn(get_commodities_by_category_fn())
     except Exception as exc:
@@ -97,9 +104,9 @@ def get_fundamentals_handler(
     *,
     request_obj,
     alpha_vantage_api_key,
-    requests_module,
-    jsonify_fn,
-    logger,
+    requests_module=requests,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     clean_value_fn,
     fundamentals_from_yfinance_fn,
     resolve_asset_fn,
@@ -210,10 +217,10 @@ def get_fundamentals_handler(
 def get_economic_calendar_handler(
     *,
     calendar_cache,
-    requests_module,
-    jsonify_fn,
-    time_module,
-    datetime_cls,
+    requests_module=requests,
+    jsonify_fn=jsonify,
+    time_module=time,
+    datetime_cls=datetime,
 ):
     current_time = time_module.time()
     if calendar_cache["data"] is not None and (current_time - calendar_cache["last_fetched"]) < 900:
@@ -281,8 +288,8 @@ def get_economic_calendar_handler(
 def get_market_sessions_handler(
     *,
     request_obj,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     exchange_session_service_module,
 ):
     market = str(request_obj.args.get("market", "us")).strip()
@@ -302,8 +309,8 @@ def get_financial_statements_handler(
     *,
     openbb_available,
     obb_module,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     obb_to_float_fn,
 ):
     if not openbb_available:
@@ -365,8 +372,8 @@ def get_sec_filings_handler(
     openbb_available,
     obb_module,
     sec_filings_service_module,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
 ):
     sym = ticker.upper().split(":")[0]
     relevant = {"10-K", "10-Q", "8-K", "10-K/A", "10-Q/A", "DEF 14A", "S-1", "20-F", "6-K"}
@@ -408,8 +415,8 @@ def get_sec_filing_detail_handler(
     accession_number,
     *,
     sec_filings_service_module,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
 ):
     sym = ticker.upper().split(":")[0]
     try:
@@ -433,8 +440,8 @@ def get_sec_intelligence_handler(
     ticker,
     *,
     sec_filings_service_module,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
 ):
     sym = ticker.upper().split(":")[0]
     try:
@@ -451,9 +458,9 @@ def get_sec_intelligence_handler(
 def get_screener_handler(
     *,
     base_dir,
-    yf_module,
-    jsonify_fn,
-    logger,
+    yf_module=yf,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     screener_query_service_module,
 ):
     try:
@@ -474,9 +481,9 @@ def get_screener_handler(
 def get_screener_presets_handler(
     *,
     base_dir,
-    yf_module,
-    jsonify_fn,
-    logger,
+    yf_module=yf,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     screener_query_service_module,
 ):
     try:
@@ -497,10 +504,10 @@ def get_screener_presets_handler(
 def get_screener_scan_handler(
     *,
     base_dir,
-    yf_module,
+    yf_module=yf,
     request_obj,
-    jsonify_fn,
-    logger,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
     screener_query_service_module,
 ):
     try:
@@ -625,7 +632,7 @@ def _disable_openbb_macro_support(obb_module, reason):
     )
 
 
-def _fetch_macro_rows_from_fred(*, indicator, requests_module):
+def _fetch_macro_rows_from_fred(*, indicator, requests_module=requests):
     series_id = indicator.get("series_id") or indicator["symbol"]
     response = requests_module.get(
         f"https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}",
@@ -655,11 +662,11 @@ def get_macro_overview_handler(
     *,
     openbb_available,
     obb_module,
-    jsonify_fn,
-    logger,
-    yf_module,
+    jsonify_fn=jsonify,
+    logger=logging.getLogger("marketmind_api"),
+    yf_module=yf,
     macro_indicators,
-    requests_module,
+    requests_module=requests,
     request_obj=None,
     akshare_service_module=None,
 ):

--- a/backend/api_market_utils.py
+++ b/backend/api_market_utils.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import pandas as pd
+import logging
+import yfinance as yf
+import numpy as np
 
-def clean_value(val, *, pd_module, np_module):
+
+def clean_value(val, *, pd_module=pd, np_module=np):
     if val is None or pd_module.isna(val):
         return None
     if isinstance(val, (np_module.int64, np_module.int32, np_module.int16, np_module.int8)):
@@ -11,7 +16,7 @@ def clean_value(val, *, pd_module, np_module):
     return val
 
 
-def get_symbol_suggestions(query, *, alpha_vantage_api_key, requests_get, logger):
+def get_symbol_suggestions(query, *, alpha_vantage_api_key, requests_get, logger=logging.getLogger("marketmind_api")):
     if not alpha_vantage_api_key:
         logger.warning("Alpha Vantage key not configured. Cannot get suggestions.")
         return []
@@ -53,7 +58,7 @@ def obb_to_float(val):
         return None
 
 
-def fundamentals_from_yfinance(sym, *, yf_module, logger):
+def fundamentals_from_yfinance(sym, *, yf_module=yf, logger=logging.getLogger("marketmind_api")):
     try:
         info = yf_module.Ticker(sym).info
         if not info or info.get("quoteType") not in ("EQUITY", "ETF", "MUTUALFUND"):

--- a/backend/api_prediction_runtime.py
+++ b/backend/api_prediction_runtime.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pandas as pd
+import numpy as np
+
 import prediction_service
 
 
@@ -20,7 +23,7 @@ def live_ensemble_signal_components(
     *,
     create_dataset_fn,
     ensemble_predict_fn,
-    np_module,
+    np_module=np,
 ):
     df = create_dataset_fn(sanitized_ticker, period="1y")
     if df.empty or len(df) < 30:
@@ -54,7 +57,7 @@ def chart_prediction_points(
     sanitized_ticker,
     *,
     live_ensemble_signal_components_fn,
-    pd_module,
+    pd_module=pd,
 ):
     signal_parts = live_ensemble_signal_components_fn(sanitized_ticker)
     if signal_parts is None:

--- a/backend/api_public.py
+++ b/backend/api_public.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import hashlib
 import hmac
 import json
@@ -198,7 +200,7 @@ def build_public_cache_key(route_group: str, *, path_params: Dict[str, Any] | No
     return f"marketmind-public:{payload['route_group']}:{digest}"
 
 
-def get_public_cache(cache_url: str | None, *, logger) -> Any:
+def get_public_cache(cache_url: str | None, *, logger=logging.getLogger("marketmind_api")) -> Any:
     global _PUBLIC_CACHE_BACKEND, _PUBLIC_CACHE_BACKEND_KEY
     cache_key = str(cache_url or "").strip()
     if _PUBLIC_CACHE_BACKEND is not None and _PUBLIC_CACHE_BACKEND_KEY == cache_key:
@@ -292,7 +294,7 @@ def build_require_public_api_auth(
     authenticate_key_fn: Callable[[str | None], Dict[str, Any]],
     get_daily_quota_fn: Callable[[Dict[str, Any]], int],
     get_daily_usage_total_fn: Callable[[Dict[str, Any], date], int],
-    logger,
+    logger=logging.getLogger("marketmind_api"),
     error_response_fn: Callable[[int, str, str], Any],
 ):
     def wrapper(*args, **kwargs):
@@ -341,7 +343,7 @@ def finalize_public_response(
     database_url: str,
     increment_public_api_daily_usage_fn,
     touch_public_api_key_last_used_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     if not is_public_api_request(getattr(request, "path", "")):
         return response

--- a/backend/api_scheduler.py
+++ b/backend/api_scheduler.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import time
+
+import yfinance as yf
+import uuid
+from datetime import datetime
+import logging
+
 
 def check_alerts_for_user(
     user_id,
     *,
     load_notifications_fn,
     save_notifications_fn,
-    yf_module,
-    logger,
-    uuid_module,
-    datetime_cls,
+    yf_module=yf,
+    logger=logging.getLogger("marketmind_api"),
+    uuid_module=uuid,
+    datetime_cls=datetime,
 ):
     notifications_data = load_notifications_fn(user_id)
     if not notifications_data["active"]:
@@ -99,7 +106,7 @@ def check_alerts_for_user(
         logger.error("Failed to check all alert prices: %s", exc)
 
 
-def check_alerts(*, iter_user_ids_fn, check_alerts_for_user_fn, logger):
+def check_alerts(*, iter_user_ids_fn, check_alerts_for_user_fn, logger=logging.getLogger("marketmind_api")):
     logger.info("Running price alert check...")
     for user_id in iter_user_ids_fn():
         try:
@@ -108,7 +115,7 @@ def check_alerts(*, iter_user_ids_fn, check_alerts_for_user_fn, logger):
             logger.error("Alert check failed for user %s: %s", user_id, exc)
 
 
-def run_scheduler(*, schedule_module, check_alerts_fn, time_module):
+def run_scheduler(*, schedule_module, check_alerts_fn, time_module=time):
     schedule_module.every(1).minutes.do(check_alerts_fn)
     while True:
         schedule_module.run_pending()

--- a/backend/api_state.py
+++ b/backend/api_state.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from datetime import datetime
+
+import logging
+
 import json
 import os
 import re
 
 
-def normalize_persistence_mode(mode, *, logger):
+def normalize_persistence_mode(mode, *, logger=logging.getLogger("marketmind_api")):
     normalized = str(mode or "json").strip().lower()
     if normalized not in {"json", "dual", "postgres"}:
         logger.warning("Unknown PERSISTENCE_MODE '%s'; defaulting to json", normalized)
@@ -13,15 +17,15 @@ def normalize_persistence_mode(mode, *, logger):
     return normalized
 
 
-def current_persistence_mode(mode, *, logger):
+def current_persistence_mode(mode, *, logger=logging.getLogger("marketmind_api")):
     return normalize_persistence_mode(mode, logger=logger)
 
 
-def sql_persistence_enabled(mode, *, logger):
+def sql_persistence_enabled(mode, *, logger=logging.getLogger("marketmind_api")):
     return current_persistence_mode(mode, logger=logger) in {"dual", "postgres"}
 
 
-def json_mirror_enabled(mode, *, logger):
+def json_mirror_enabled(mode, *, logger=logging.getLogger("marketmind_api")):
     return current_persistence_mode(mode, logger=logger) == "dual"
 
 
@@ -30,7 +34,7 @@ def ensure_user_state_storage_ready(*, sql_enabled, ensure_database_ready_fn, da
         ensure_database_ready_fn(database_url)
 
 
-def init_history_db(*, get_db_fn, logger):
+def init_history_db(*, get_db_fn, logger=logging.getLogger("marketmind_api")):
     conn = None
     try:
         conn = get_db_fn()
@@ -76,7 +80,7 @@ def iter_user_ids(
     session_scope,
     database_url,
     list_app_user_ids_db_fn,
-    logger,
+    logger=logging.getLogger("marketmind_api"),
 ):
     user_ids = set()
     if os.path.isdir(user_data_dir):
@@ -466,7 +470,7 @@ def save_watchlist(
     )
 
 
-def record_portfolio_snapshot_legacy(portfolio_data, user_id, *, get_db_fn, logger, datetime_cls):
+def record_portfolio_snapshot_legacy(portfolio_data, user_id, *, get_db_fn, logger=logging.getLogger("marketmind_api"), datetime_cls=datetime):
     total_value = portfolio_data["cash"]
     for _, pos in portfolio_data.get("positions", {}).items():
         total_value += pos["shares"] * pos["avg_cost"]

--- a/backend/screener_query_service.py
+++ b/backend/screener_query_service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import yfinance as yf
+import logging
+
 import math
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -203,8 +206,8 @@ def _sanitize_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 def scan(
     *,
     base_dir: str,
-    yf_module,
-    logger,
+    yf_module=yf,
+    logger=logging.getLogger("marketmind_api"),
     preset: str = "gainers",
     filters: Optional[Dict[str, Any]] = None,
     sort: Optional[str] = None,
@@ -269,7 +272,7 @@ def scan(
     }
 
 
-def movers_payload(*, base_dir: str, yf_module, logger, limit: int = 8) -> Dict[str, Any]:
+def movers_payload(*, base_dir: str, yf_module=yf, logger=logging.getLogger("marketmind_api"), limit: int = 8) -> Dict[str, Any]:
     gainers = scan(base_dir=base_dir, yf_module=yf_module, logger=logger, preset="gainers", limit=limit, offset=0)
     losers = scan(base_dir=base_dir, yf_module=yf_module, logger=logger, preset="losers", limit=limit, offset=0)
     active = scan(base_dir=base_dir, yf_module=yf_module, logger=logger, preset="active", limit=limit, offset=0)

--- a/backend/screener_snapshot_service.py
+++ b/backend/screener_snapshot_service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+import yfinance as yf
+
 import json
 import math
 import os
@@ -236,7 +239,7 @@ def _extract_downloaded_histories(raw_download: Any, tickers: List[str]) -> Dict
     return histories
 
 
-def _fetch_histories(*, tickers: List[str], yf_module, logger) -> Dict[str, Any]:
+def _fetch_histories(*, tickers: List[str], yf_module=yf, logger=logging.getLogger("marketmind_api")) -> Dict[str, Any]:
     histories: Dict[str, Any] = {}
     period = _history_period_for_lookback(TRADING_LOOKBACK)
 
@@ -261,7 +264,7 @@ def _fetch_histories(*, tickers: List[str], yf_module, logger) -> Dict[str, Any]
     return histories
 
 
-def _fetch_metadata(*, universe: List[Dict[str, object]], yf_module, logger) -> Dict[str, Dict[str, Any]]:
+def _fetch_metadata(*, universe: List[Dict[str, object]], yf_module=yf, logger=logging.getLogger("marketmind_api")) -> Dict[str, Dict[str, Any]]:
     metadata: Dict[str, Dict[str, Any]] = {}
 
     for record in universe:
@@ -435,7 +438,7 @@ def _build_snapshot(*, histories: Dict[str, Any], metadata: Dict[str, Dict[str, 
     return pl.DataFrame(rows), warnings
 
 
-def ensure_snapshot(*, base_dir: str, yf_module, logger, force_refresh: bool = False) -> Dict[str, Any]:
+def ensure_snapshot(*, base_dir: str, yf_module=yf, logger=logging.getLogger("marketmind_api"), force_refresh: bool = False) -> Dict[str, Any]:
     now_dt = _utcnow()
     os.makedirs(cache_dir(base_dir=base_dir), exist_ok=True)
 


### PR DESCRIPTION
Removes ~200 lines of ambient-dependency injection noise from the api.py composition root. The ambient singletons (jsonify, pandas, numpy, uuid, datetime, re, math, time, requests, module logger) were threaded into nearly every handler call as `*_fn`/`*_module`/`*_cls` kwargs.

Approach: give those params defaults bound to the real singletons in the receiving modules, then drop the redundant kwargs at api.py call sites. Signatures stay compatible (params kept with defaults) so direct-call handler tests still override them. **api.py loses 199 lines.**

**`yf_module` is deliberately kept injected** — yfinance is a genuine test seam (`test_exchange_session_routes` patches `api.yf`, which must flow to handlers). Genuine collaborators (persistence, model predictors, auth fns, log_api_error) remain injected.

Behavior-preserving: defaults equal the values api.py passed (e.g. logger default `getLogger('marketmind_api')` is the same instance). ruff clean; full sweep unchanged from baseline (29 pass, same 5 env-only failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)