### PR TITLE
Frontend refactor (F5): extract FundamentalsPage components + formatters

### DIFF
--- a/frontend/src/components/FundamentalsPage.js
+++ b/frontend/src/components/FundamentalsPage.js
@@ -15,16 +15,14 @@ import {
     Activity,
 } from 'lucide-react';
 import { API_ENDPOINTS, apiRequest } from '../config/api';
+import { currencyPrefix, sectionTitleClass } from './fundamentals/format';
+import { FinancialTable, MetricCard, TabButton, SentimentBadge, ResearchProfileList, AnnouncementsPanel } from './fundamentals/components';
 import {
     getMarketSessionLabel,
     getMarketSessionSummary,
     getMarketSessionToneClasses,
     getTimezoneLabel,
 } from './ui/marketSessionUtils';
-import {
-    getSentimentLabel,
-    getSentimentToneClasses,
-} from './ui/sentimentUtils';
 
 const US_TABS = [
     { key: 'overview', label: 'Overview' },
@@ -71,29 +69,6 @@ const normalizeAssetInput = (input, fallbackMarket = 'us') => {
 
 const isUsAsset = (asset) => !asset || asset.market === 'US';
 
-const fmtBig = (val, prefix = '') => {
-    if (val === null || val === undefined || val === 'N/A' || val === 'None') return '—';
-    const num = typeof val === 'string' ? parseFloat(val) : val;
-    if (isNaN(num)) return '—';
-    const abs = Math.abs(num);
-    if (abs >= 1e12) return `${prefix}${(num / 1e12).toFixed(2)}T`;
-    if (abs >= 1e9) return `${prefix}${(num / 1e9).toFixed(2)}B`;
-    if (abs >= 1e6) return `${prefix}${(num / 1e6).toFixed(2)}M`;
-    return `${prefix}${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-};
-
-const currencyPrefix = (currency) => {
-    switch (String(currency || '').toUpperCase()) {
-    case 'HKD':
-        return 'HK$';
-    case 'CNY':
-        return 'CN¥';
-    case 'USD':
-    default:
-        return '$';
-    }
-};
-
 const INCOME_ROWS = [
     { label: 'Revenue', key: 'revenue' },
     { label: 'Gross Profit', key: 'gross_profit' },
@@ -119,153 +94,6 @@ const CASHFLOW_ROWS = [
     { label: 'Capital Expenditures', key: 'capex' },
     { label: 'Free Cash Flow', key: 'free_cf' },
 ];
-
-const metricToneClass = {
-    accent: 'text-mm-accent-primary',
-    positive: 'text-mm-positive',
-    warning: 'text-mm-warning',
-    tertiary: 'text-mm-text-tertiary',
-};
-
-const sectionTitleClass = 'text-2xl font-semibold text-mm-text-primary mb-6';
-
-const FinancialTable = ({ title, rows, data }) => {
-    if (!data || data.length === 0) return null;
-    const periods = data.map((d) => d.period);
-
-    return (
-        <div className="ui-panel overflow-hidden">
-            <div className="px-5 py-4 border-b border-mm-border">
-                <h3 className="text-sm font-semibold text-mm-text-primary">{title}</h3>
-            </div>
-            <div className="overflow-x-auto">
-                <table className="min-w-full text-sm">
-                    <thead className="bg-mm-surface-subtle">
-                        <tr>
-                            <th className="px-5 py-2.5 text-left text-xs text-mm-text-tertiary font-semibold uppercase tracking-[0.14em]">Metric</th>
-                            {periods.map((p) => (
-                                <th key={p} className="px-5 py-2.5 text-right text-xs text-mm-text-tertiary font-semibold uppercase tracking-[0.14em]">
-                                    {p}
-                                </th>
-                            ))}
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-mm-border">
-                        {rows.map(({ label, key, raw }) => (
-                            <tr key={key} className="hover:bg-mm-surface-subtle/80">
-                                <td className="px-5 py-2.5 text-mm-text-secondary font-medium">{label}</td>
-                                {data.map((d) => (
-                                    <td key={d.period} className="px-5 py-2.5 text-right text-mm-text-primary">
-                                        {raw ? fmtBig(d[key]) : fmtBig(d[key], '$')}
-                                    </td>
-                                ))}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    );
-};
-
-const MetricCard = ({ title, value, icon: Icon, tone = 'accent' }) => (
-    <div className="ui-panel-subtle p-4">
-        <div className="flex items-center justify-between mb-2">
-            <span className="text-sm text-mm-text-secondary">{title}</span>
-            {Icon && <Icon className={`w-4 h-4 ${metricToneClass[tone] || metricToneClass.accent}`} />}
-        </div>
-        <p className="text-xl font-semibold text-mm-text-primary">{value}</p>
-    </div>
-);
-
-const TabButton = ({ active, children, onClick }) => (
-    <button
-        onClick={onClick}
-        className={active
-            ? 'rounded-control bg-mm-accent-primary px-5 py-2 text-sm font-semibold text-white shadow-card'
-            : 'rounded-control border border-mm-border bg-mm-surface px-5 py-2 text-sm font-semibold text-mm-text-secondary transition hover:bg-mm-surface-subtle hover:text-mm-text-primary'}
-    >
-        {children}
-    </button>
-);
-
-const SentimentBadge = ({ sentiment, prefix = '' }) => {
-    const label = getSentimentLabel(sentiment);
-    if (!label) {
-        return null;
-    }
-    return (
-        <span className={`inline-flex items-center rounded-pill border px-2 py-0.5 text-[11px] font-semibold ${getSentimentToneClasses(sentiment)}`}>
-            {prefix ? `${prefix}: ${label}` : label}
-        </span>
-    );
-};
-
-const ResearchProfileList = ({ items }) => {
-    if (!Array.isArray(items) || items.length === 0) return null;
-    return (
-        <div className="ui-panel p-6">
-            <h3 className={sectionTitleClass}>Company Research</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {items.map((item) => (
-                    <div key={`${item.label}-${item.value}`} className="ui-panel-subtle p-4">
-                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-mm-text-tertiary">{item.label}</p>
-                        <p className="mt-2 text-sm leading-6 text-mm-text-primary break-words">{item.value}</p>
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
-};
-
-const AnnouncementsPanel = ({ items }) => {
-    if (!Array.isArray(items) || items.length === 0) {
-        return (
-            <div className="ui-panel-subtle py-16 text-mm-text-secondary text-center">
-                <FileText className="w-12 h-12 mx-auto mb-3 opacity-40" />
-                <p>No company announcements were returned for this asset.</p>
-            </div>
-        );
-    }
-
-    return (
-        <div className="ui-panel p-6">
-            <div className="flex items-center gap-2 mb-4">
-                <FileText className="w-5 h-5 text-mm-accent-primary" />
-                <h3 className="text-lg font-semibold text-mm-text-primary">Company Announcements</h3>
-            </div>
-            <div className="space-y-3">
-                {items.map((item, index) => (
-                    <a
-                        key={`${item.link || item.title}-${index}`}
-                        href={item.link || '#'}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="block rounded-card border border-mm-border bg-mm-surface px-4 py-4 transition hover:bg-mm-surface-subtle"
-                    >
-                        <div className="flex flex-wrap items-center gap-2 text-xs text-mm-text-tertiary">
-                            <span className="rounded-pill border border-mm-border px-2 py-0.5 font-semibold uppercase tracking-[0.12em]">
-                                {item.type || 'Announcement'}
-                            </span>
-                            {item.date ? <span>{item.date}</span> : null}
-                            {item.publisher ? <span>• {item.publisher}</span> : null}
-                            <SentimentBadge sentiment={item.sentiment} />
-                        </div>
-                        <p className="mt-3 text-sm font-semibold text-mm-text-primary">{item.title || item.description || 'Company announcement'}</p>
-                        {item.description && item.description !== item.title ? (
-                            <p className="mt-2 text-sm leading-6 text-mm-text-secondary">{item.description}</p>
-                        ) : null}
-                        {item.link ? (
-                            <span className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-mm-accent-primary">
-                                Open source link <ExternalLink className="w-3 h-3" />
-                            </span>
-                        ) : null}
-                    </a>
-                ))}
-            </div>
-        </div>
-    );
-};
 
 const FundamentalsPage = () => {
     const { sharedTicker: initialTicker, clearTicker: onConsumeInitialTicker } = useNavigation();

--- a/frontend/src/components/fundamentals/components.js
+++ b/frontend/src/components/fundamentals/components.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { FileText, ExternalLink } from 'lucide-react';
+import { fmtBig, metricToneClass, sectionTitleClass } from './format';
+import { getSentimentLabel, getSentimentToneClasses } from '../ui/sentimentUtils';
+
+export const FinancialTable = ({ title, rows, data }) => {
+    if (!data || data.length === 0) return null;
+    const periods = data.map((d) => d.period);
+
+    return (
+        <div className="ui-panel overflow-hidden">
+            <div className="px-5 py-4 border-b border-mm-border">
+                <h3 className="text-sm font-semibold text-mm-text-primary">{title}</h3>
+            </div>
+            <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                    <thead className="bg-mm-surface-subtle">
+                        <tr>
+                            <th className="px-5 py-2.5 text-left text-xs text-mm-text-tertiary font-semibold uppercase tracking-[0.14em]">Metric</th>
+                            {periods.map((p) => (
+                                <th key={p} className="px-5 py-2.5 text-right text-xs text-mm-text-tertiary font-semibold uppercase tracking-[0.14em]">
+                                    {p}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-mm-border">
+                        {rows.map(({ label, key, raw }) => (
+                            <tr key={key} className="hover:bg-mm-surface-subtle/80">
+                                <td className="px-5 py-2.5 text-mm-text-secondary font-medium">{label}</td>
+                                {data.map((d) => (
+                                    <td key={d.period} className="px-5 py-2.5 text-right text-mm-text-primary">
+                                        {raw ? fmtBig(d[key]) : fmtBig(d[key], '$')}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export const MetricCard = ({ title, value, icon: Icon, tone = 'accent' }) => (
+    <div className="ui-panel-subtle p-4">
+        <div className="flex items-center justify-between mb-2">
+            <span className="text-sm text-mm-text-secondary">{title}</span>
+            {Icon && <Icon className={`w-4 h-4 ${metricToneClass[tone] || metricToneClass.accent}`} />}
+        </div>
+        <p className="text-xl font-semibold text-mm-text-primary">{value}</p>
+    </div>
+);
+
+export const TabButton = ({ active, children, onClick }) => (
+    <button
+        onClick={onClick}
+        className={active
+            ? 'rounded-control bg-mm-accent-primary px-5 py-2 text-sm font-semibold text-white shadow-card'
+            : 'rounded-control border border-mm-border bg-mm-surface px-5 py-2 text-sm font-semibold text-mm-text-secondary transition hover:bg-mm-surface-subtle hover:text-mm-text-primary'}
+    >
+        {children}
+    </button>
+);
+
+export const SentimentBadge = ({ sentiment, prefix = '' }) => {
+    const label = getSentimentLabel(sentiment);
+    if (!label) {
+        return null;
+    }
+    return (
+        <span className={`inline-flex items-center rounded-pill border px-2 py-0.5 text-[11px] font-semibold ${getSentimentToneClasses(sentiment)}`}>
+            {prefix ? `${prefix}: ${label}` : label}
+        </span>
+    );
+};
+
+export const ResearchProfileList = ({ items }) => {
+    if (!Array.isArray(items) || items.length === 0) return null;
+    return (
+        <div className="ui-panel p-6">
+            <h3 className={sectionTitleClass}>Company Research</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {items.map((item) => (
+                    <div key={`${item.label}-${item.value}`} className="ui-panel-subtle p-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-mm-text-tertiary">{item.label}</p>
+                        <p className="mt-2 text-sm leading-6 text-mm-text-primary break-words">{item.value}</p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export const AnnouncementsPanel = ({ items }) => {
+    if (!Array.isArray(items) || items.length === 0) {
+        return (
+            <div className="ui-panel-subtle py-16 text-mm-text-secondary text-center">
+                <FileText className="w-12 h-12 mx-auto mb-3 opacity-40" />
+                <p>No company announcements were returned for this asset.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="ui-panel p-6">
+            <div className="flex items-center gap-2 mb-4">
+                <FileText className="w-5 h-5 text-mm-accent-primary" />
+                <h3 className="text-lg font-semibold text-mm-text-primary">Company Announcements</h3>
+            </div>
+            <div className="space-y-3">
+                {items.map((item, index) => (
+                    <a
+                        key={`${item.link || item.title}-${index}`}
+                        href={item.link || '#'}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block rounded-card border border-mm-border bg-mm-surface px-4 py-4 transition hover:bg-mm-surface-subtle"
+                    >
+                        <div className="flex flex-wrap items-center gap-2 text-xs text-mm-text-tertiary">
+                            <span className="rounded-pill border border-mm-border px-2 py-0.5 font-semibold uppercase tracking-[0.12em]">
+                                {item.type || 'Announcement'}
+                            </span>
+                            {item.date ? <span>{item.date}</span> : null}
+                            {item.publisher ? <span>• {item.publisher}</span> : null}
+                            <SentimentBadge sentiment={item.sentiment} />
+                        </div>
+                        <p className="mt-3 text-sm font-semibold text-mm-text-primary">{item.title || item.description || 'Company announcement'}</p>
+                        {item.description && item.description !== item.title ? (
+                            <p className="mt-2 text-sm leading-6 text-mm-text-secondary">{item.description}</p>
+                        ) : null}
+                        {item.link ? (
+                            <span className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-mm-accent-primary">
+                                Open source link <ExternalLink className="w-3 h-3" />
+                            </span>
+                        ) : null}
+                    </a>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/fundamentals/format.js
+++ b/frontend/src/components/fundamentals/format.js
@@ -1,0 +1,33 @@
+// Pure formatters, tone map, and shared section heading style for fundamentals.
+
+export const fmtBig = (val, prefix = '') => {
+    if (val === null || val === undefined || val === 'N/A' || val === 'None') return '—';
+    const num = typeof val === 'string' ? parseFloat(val) : val;
+    if (isNaN(num)) return '—';
+    const abs = Math.abs(num);
+    if (abs >= 1e12) return `${prefix}${(num / 1e12).toFixed(2)}T`;
+    if (abs >= 1e9) return `${prefix}${(num / 1e9).toFixed(2)}B`;
+    if (abs >= 1e6) return `${prefix}${(num / 1e6).toFixed(2)}M`;
+    return `${prefix}${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+};
+
+export const currencyPrefix = (currency) => {
+    switch (String(currency || '').toUpperCase()) {
+    case 'HKD':
+        return 'HK$';
+    case 'CNY':
+        return 'CN¥';
+    case 'USD':
+    default:
+        return '$';
+    }
+};
+
+export const metricToneClass = {
+    accent: 'text-mm-accent-primary',
+    positive: 'text-mm-positive',
+    warning: 'text-mm-warning',
+    tertiary: 'text-mm-text-tertiary',
+};
+
+export const sectionTitleClass = 'text-2xl font-semibold text-mm-text-primary mb-6';


### PR DESCRIPTION
Extract the six presentational components (FinancialTable, MetricCard, TabButton, SentimentBadge, ResearchProfileList, AnnouncementsPanel) into `components/fundamentals/components.js` and the shared formatters/tone-map/heading style into `components/fundamentals/format.js`. **Page: 1031 → 863 lines**, keeping its fetch/state logic and main-only data. Pure code movement, guarded by FundamentalsPage's existing tests. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)