### PR TITLE
test: cover extracted formatter + util modules (lock-in)

### DIFF
--- a/frontend/src/components/fundamentals/format.test.js
+++ b/frontend/src/components/fundamentals/format.test.js
@@ -1,0 +1,52 @@
+import { fmtBig, currencyPrefix, metricToneClass, sectionTitleClass } from './format';
+
+describe('fundamentals/format', () => {
+    describe('fmtBig', () => {
+        test('returns an em dash for missing/sentinel/non-numeric values', () => {
+            expect(fmtBig(null)).toBe('—');
+            expect(fmtBig(undefined)).toBe('—');
+            expect(fmtBig('N/A')).toBe('—');
+            expect(fmtBig('None')).toBe('—');
+            expect(fmtBig('not-a-number')).toBe('—');
+        });
+
+        test('abbreviates by magnitude using the absolute value', () => {
+            expect(fmtBig(2.84e12)).toBe('2.84T');
+            expect(fmtBig(1e9)).toBe('1.00B');
+            expect(fmtBig(1e6)).toBe('1.00M');
+            expect(fmtBig(-2e12)).toBe('-2.00T');
+        });
+
+        test('parses numeric strings', () => {
+            expect(fmtBig('1500000')).toBe('1.50M');
+        });
+
+        test('applies the prefix and groups sub-million values with two decimals', () => {
+            expect(fmtBig(1234.5)).toBe('1,234.50');
+            expect(fmtBig(2.84e12, 'HK$')).toBe('HK$2.84T');
+        });
+    });
+
+    describe('currencyPrefix', () => {
+        test('maps known currencies, case-insensitively', () => {
+            expect(currencyPrefix('HKD')).toBe('HK$');
+            expect(currencyPrefix('hkd')).toBe('HK$');
+            expect(currencyPrefix('CNY')).toBe('CN¥');
+            expect(currencyPrefix('USD')).toBe('$');
+        });
+
+        test('defaults to $ for unknown/empty/null', () => {
+            expect(currencyPrefix('EUR')).toBe('$');
+            expect(currencyPrefix('')).toBe('$');
+            expect(currencyPrefix(null)).toBe('$');
+            expect(currencyPrefix(undefined)).toBe('$');
+        });
+    });
+
+    test('metricToneClass maps tone keys to classes and sectionTitleClass is a string', () => {
+        expect(metricToneClass.accent).toBe('text-mm-accent-primary');
+        expect(metricToneClass.positive).toBe('text-mm-positive');
+        expect(Object.keys(metricToneClass)).toEqual(['accent', 'positive', 'warning', 'tertiary']);
+        expect(typeof sectionTitleClass).toBe('string');
+    });
+});

--- a/frontend/src/components/fundamentals/fundamentalsUtils.test.js
+++ b/frontend/src/components/fundamentals/fundamentalsUtils.test.js
@@ -1,0 +1,8 @@
+import { MARKET_OPTIONS } from './fundamentalsUtils';
+
+describe('fundamentals/fundamentalsUtils', () => {
+    test('MARKET_OPTIONS lists the supported fundamentals markets (us/hk/cn)', () => {
+        expect(MARKET_OPTIONS.map((o) => o.value)).toEqual(['us', 'hk', 'cn']);
+        MARKET_OPTIONS.forEach((o) => expect(typeof o.label).toBe('string'));
+    });
+});

--- a/frontend/src/components/paper/format.test.js
+++ b/frontend/src/components/paper/format.test.js
@@ -1,0 +1,48 @@
+import { formatCurrency, formatNum, formatPercent } from './format';
+
+describe('paper/format', () => {
+    describe('formatCurrency', () => {
+        test('falls back to $0.00 (not N/A) for null/undefined/NaN', () => {
+            expect(formatCurrency(null)).toBe('$0.00');
+            expect(formatCurrency(undefined)).toBe('$0.00');
+            expect(formatCurrency(NaN)).toBe('$0.00');
+        });
+
+        test('formats as en-US currency with grouping', () => {
+            expect(formatCurrency(0)).toBe('$0.00');
+            expect(formatCurrency(1234.5)).toBe('$1,234.50');
+            expect(formatCurrency(108432)).toBe('$108,432.00');
+        });
+    });
+
+    describe('formatNum', () => {
+        test('falls back to 0.00 for null/undefined/NaN', () => {
+            expect(formatNum(null)).toBe('0.00');
+            expect(formatNum(undefined)).toBe('0.00');
+            expect(formatNum(NaN)).toBe('0.00');
+        });
+
+        test('respects the digits argument (default 2)', () => {
+            expect(formatNum(3.14159)).toBe('3.14');
+            expect(formatNum(3.14159, 4)).toBe('3.1416');
+            expect(formatNum(5, 0)).toBe('5');
+        });
+
+        test('parses numeric strings', () => {
+            expect(formatNum('12.5')).toBe('12.50');
+        });
+    });
+
+    describe('formatPercent', () => {
+        test('falls back to 0.00% for null/undefined/NaN', () => {
+            expect(formatPercent(null)).toBe('0.00%');
+            expect(formatPercent(NaN)).toBe('0.00%');
+        });
+
+        test('multiplies a ratio by 100 and appends %', () => {
+            expect(formatPercent(0.1234)).toBe('12.34%');
+            expect(formatPercent(0)).toBe('0.00%');
+            expect(formatPercent(0.05, 1)).toBe('5.0%');
+        });
+    });
+});

--- a/frontend/src/components/prediction-markets/format.test.js
+++ b/frontend/src/components/prediction-markets/format.test.js
@@ -1,0 +1,50 @@
+import {
+    formatCurrency,
+    formatPercent,
+    formatProbability,
+    formatProbabilityDelta,
+} from './format';
+
+describe('prediction-markets/format', () => {
+    describe('formatCurrency', () => {
+        test('falls back to $0.00 for null/undefined/NaN', () => {
+            expect(formatCurrency(null)).toBe('$0.00');
+            expect(formatCurrency(NaN)).toBe('$0.00');
+        });
+
+        test('formats as en-US currency', () => {
+            expect(formatCurrency(1234.5)).toBe('$1,234.50');
+        });
+    });
+
+    describe('formatPercent', () => {
+        test('falls back to 0.00% for null/undefined/NaN', () => {
+            expect(formatPercent(null)).toBe('0.00%');
+            expect(formatPercent(NaN)).toBe('0.00%');
+        });
+
+        test('signs the value (a raw percentage, not a ratio)', () => {
+            expect(formatPercent(0)).toBe('+0.00%');
+            expect(formatPercent(4.2)).toBe('+4.20%');
+            expect(formatPercent(-1.5)).toBe('-1.50%');
+        });
+    });
+
+    describe('formatProbability', () => {
+        test('renders a 0-1 price as a one-decimal percentage', () => {
+            expect(formatProbability(0.732)).toBe('73.2%');
+            expect(formatProbability(0)).toBe('0.0%');
+            expect(formatProbability(null)).toBe('0.0%');
+            expect(formatProbability(1)).toBe('100.0%');
+        });
+    });
+
+    describe('formatProbabilityDelta', () => {
+        test('signs the delta and labels it in points', () => {
+            expect(formatProbabilityDelta(0.05)).toBe('+5.0 pts');
+            expect(formatProbabilityDelta(-0.021)).toBe('-2.1 pts');
+            expect(formatProbabilityDelta(0)).toBe('+0.0 pts');
+            expect(formatProbabilityDelta(null)).toBe('+0.0 pts');
+        });
+    });
+});

--- a/frontend/src/components/search/format.js
+++ b/frontend/src/components/search/format.js
@@ -1,7 +1,6 @@
 // Pure display formatters for search result cards.
 
-export // --- Helpers for Jimmy's cards ---
-const formatLargeNumber = (num) => {
+export const formatLargeNumber = (num) => {
     if (!num || isNaN(num)) return 'N/A';
     if (num >= 1e12) return `${(num / 1e12).toFixed(2)}T`;
     if (num >= 1e9) return `${(num / 1e9).toFixed(2)}B`;

--- a/frontend/src/components/search/format.test.js
+++ b/frontend/src/components/search/format.test.js
@@ -1,0 +1,77 @@
+import {
+    formatLargeNumber,
+    formatNum,
+    formatCurrency,
+    formatSignedPercent,
+} from './format';
+
+describe('search/format', () => {
+    describe('formatLargeNumber', () => {
+        test('returns N/A for falsy or non-numeric input', () => {
+            expect(formatLargeNumber(0)).toBe('N/A');
+            expect(formatLargeNumber(null)).toBe('N/A');
+            expect(formatLargeNumber(undefined)).toBe('N/A');
+            expect(formatLargeNumber(NaN)).toBe('N/A');
+            expect(formatLargeNumber('abc')).toBe('N/A');
+        });
+
+        test('abbreviates at the trillion/billion/million boundaries', () => {
+            expect(formatLargeNumber(2.84e12)).toBe('2.84T');
+            expect(formatLargeNumber(1e12)).toBe('1.00T');
+            expect(formatLargeNumber(1e9)).toBe('1.00B');
+            expect(formatLargeNumber(1.5e6)).toBe('1.50M');
+        });
+
+        test('just below a boundary uses the smaller unit', () => {
+            expect(formatLargeNumber(999e6)).toBe('999.00M');
+        });
+
+        test('values below a million are grouped, not abbreviated', () => {
+            expect(formatLargeNumber(12345)).toBe('12,345');
+        });
+    });
+
+    describe('formatNum', () => {
+        test('returns N/A for null/undefined/NaN', () => {
+            expect(formatNum(null)).toBe('N/A');
+            expect(formatNum(undefined)).toBe('N/A');
+            expect(formatNum(NaN)).toBe('N/A');
+        });
+
+        test('formats to two decimals, 0 included', () => {
+            expect(formatNum(0)).toBe('0.00');
+            expect(formatNum(3.14159)).toBe('3.14');
+            expect(formatNum(-2.5)).toBe('-2.50');
+        });
+
+        test('appends % when isPercent is true', () => {
+            expect(formatNum(12.5, true)).toBe('12.50%');
+        });
+    });
+
+    describe('formatCurrency', () => {
+        test('returns N/A (not $0.00) for null/undefined/NaN', () => {
+            expect(formatCurrency(null)).toBe('N/A');
+            expect(formatCurrency(undefined)).toBe('N/A');
+            expect(formatCurrency(NaN)).toBe('N/A');
+        });
+
+        test('prefixes $ with two decimals', () => {
+            expect(formatCurrency(0)).toBe('$0.00');
+            expect(formatCurrency(182.5)).toBe('$182.50');
+        });
+    });
+
+    describe('formatSignedPercent', () => {
+        test('returns N/A for null/undefined/NaN', () => {
+            expect(formatSignedPercent(null)).toBe('N/A');
+            expect(formatSignedPercent(NaN)).toBe('N/A');
+        });
+
+        test('adds a leading + for zero and positive, - stays for negative', () => {
+            expect(formatSignedPercent(0)).toBe('+0.00%');
+            expect(formatSignedPercent(1.234)).toBe('+1.23%');
+            expect(formatSignedPercent(-4.2)).toBe('-4.20%');
+        });
+    });
+});

--- a/frontend/src/components/search/searchUtils.test.js
+++ b/frontend/src/components/search/searchUtils.test.js
@@ -1,0 +1,22 @@
+import { MARKET_OPTIONS, isUsAsset } from './searchUtils';
+
+describe('search/searchUtils', () => {
+    test('MARKET_OPTIONS lists us/hk/cn/all with labels', () => {
+        expect(MARKET_OPTIONS.map((o) => o.value)).toEqual(['us', 'hk', 'cn', 'all']);
+        MARKET_OPTIONS.forEach((o) => expect(typeof o.label).toBe('string'));
+    });
+
+    describe('isUsAsset', () => {
+        test('treats missing assets as US (default market)', () => {
+            expect(isUsAsset(null)).toBe(true);
+            expect(isUsAsset(undefined)).toBe(true);
+        });
+
+        test('is true only when market is exactly "US"', () => {
+            expect(isUsAsset({ market: 'US' })).toBe(true);
+            expect(isUsAsset({ market: 'HK' })).toBe(false);
+            expect(isUsAsset({ market: 'us' })).toBe(false);
+            expect(isUsAsset({})).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
First lock-in PR: **35 unit tests** across the pure helper modules the F5 extractions produced (search/paper/prediction-markets/fundamentals `format.js`, plus `searchUtils`/`fundamentalsUtils`). These were only covered indirectly through page tests; now their behavior is locked in — including the intentional per-module `formatCurrency` difference (search → `N/A`, paper/prediction → `$0.00`), magnitude boundaries, sign handling, and null/NaN edges. Also tidies a leftover `export // comment` artifact in search/format.js.

Full suite: 83 → 118 tests / 23 → 29 suites. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)