### PR TITLE
hotfix: fix import/first lint error breaking main

### DIFF
--- a/frontend/src/components/prediction-markets/usePredictionMarketsData.test.js
+++ b/frontend/src/components/prediction-markets/usePredictionMarketsData.test.js
@@ -1,14 +1,15 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAuth } from '@clerk/clerk-react';
+import { API_ENDPOINTS, apiRequest } from '../../config/api';
+import usePredictionMarketsData from './usePredictionMarketsData';
 
+// jest.mock calls are hoisted above the imports by babel-jest, so useAuth /
+// apiRequest are already mocks by the time they are imported above.
 jest.mock('@clerk/clerk-react', () => ({ useAuth: jest.fn() }));
 jest.mock('../../config/api', () => ({
     ...jest.requireActual('../../config/api'),
     apiRequest: jest.fn(),
 }));
-
-import { useAuth } from '@clerk/clerk-react';
-import { API_ENDPOINTS, apiRequest } from '../../config/api';
-import usePredictionMarketsData from './usePredictionMarketsData';
 
 const MARKETS = [{ id: 'm1', question: 'Will X happen?' }];
 


### PR DESCRIPTION
PR #160 landed a test whose `jest.mock` calls sat between imports, tripping eslint `import/first` and turning main's frontend-checks red. Reorders imports to the top with jest.mock after (babel-jest hoists the mocks anyway). Verified with the full `run_frontend_checks.sh` (lint + test + build all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)