### PR TITLE
test: de-flake the heavy page suites (stability)

### DIFF
--- a/frontend/run_frontend_checks.sh
+++ b/frontend/run_frontend_checks.sh
@@ -9,5 +9,8 @@ export CI="${CI:-true}"
 export REACT_APP_CLERK_PUBLISHABLE_KEY="${REACT_APP_CLERK_PUBLISHABLE_KEY:-pk_test_dummy}"
 
 npm run lint
-npm test -- --watchAll=false
+# Cap jest workers so the heavy jsdom page suites don't contend for CPU on
+# many-core machines (a source of spurious async-timeout flakiness). 50% keeps
+# CI (few cores) effectively serial while still parallelising locally.
+npm test -- --watchAll=false --maxWorkers=50%
 npm run build

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,14 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
+
+// The heavy full-page suites (SearchPage, FundamentalsPage, ScreenerPage,
+// PredictionMarketsPage) do real async rendering — framer-motion animations
+// plus fetch-driven state — which can exceed the default 1s `waitFor` and 5s
+// per-test timeouts when jest runs many workers in parallel on a multi-core
+// machine. Give async queries and tests extra headroom so parallel CPU
+// contention doesn't produce spurious "Unable to find …" timeouts. A genuinely
+// missing element still fails, just after a longer wait.
+jest.setTimeout(15000);
+configure({ asyncUtilTimeout: 5000 });


### PR DESCRIPTION
The full-page suites (SearchPage/FundamentalsPage/ScreenerPage/PredictionMarketsPage) intermittently timed out under parallel load on many-core machines — jest's ~cores-1 workers contend for CPU and push `waitFor` past its default 1s async timeout ("Unable to find …").

Fix (two machine-independent levers): raise `asyncUtilTimeout` to 5s and jest per-test timeout to 15s in setupTests, and cap `--maxWorkers=50%` in run_frontend_checks.sh. A truly missing element still fails, just later.

**Verified: 3 consecutive full-suite runs pass 36/36** where it previously flaked ~50%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)