### PR TITLE
test: cover getting-started components (lock-in)

### DIFF
--- a/frontend/src/components/getting-started/ChapterContent.test.js
+++ b/frontend/src/components/getting-started/ChapterContent.test.js
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ChapterContent from './ChapterContent';
+
+const chapter = {
+    estimatedMinutes: 10,
+    content: [
+        { type: 'paragraph', text: 'Hello paragraph' },
+        { type: 'heading', text: 'Section Heading' },
+        { type: 'list', items: ['first item', 'second item'] },
+        { type: 'note', text: 'Important note' },
+    ],
+};
+
+describe('ChapterContent', () => {
+    test('renders each content block type and the read estimate', () => {
+        render(<ChapterContent chapter={chapter} isCompleted={false} onToggleComplete={() => {}} />);
+        expect(screen.getByText('Hello paragraph')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Section Heading' })).toBeInTheDocument();
+        expect(screen.getByText('first item')).toBeInTheDocument();
+        expect(screen.getByText('Important note')).toBeInTheDocument();
+        expect(screen.getByText('10 min read')).toBeInTheDocument();
+    });
+
+    test('the complete button toggles completion', () => {
+        const onToggleComplete = jest.fn();
+        render(<ChapterContent chapter={chapter} isCompleted={false} onToggleComplete={onToggleComplete} />);
+        fireEvent.click(screen.getByRole('button', { name: /Complete/ }));
+        expect(onToggleComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows Done when the chapter is completed', () => {
+        render(<ChapterContent chapter={chapter} isCompleted onToggleComplete={() => {}} />);
+        expect(screen.getByRole('button', { name: /Done/ })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/getting-started/ChapterSearch.test.js
+++ b/frontend/src/components/getting-started/ChapterSearch.test.js
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { learningModules } from '../../data/content';
+import ChapterSearch from './ChapterSearch';
+
+describe('ChapterSearch', () => {
+    test('shows the empty prompt before typing', () => {
+        render(<ChapterSearch onSelectResult={jest.fn()} onClose={jest.fn()} />);
+        expect(screen.getByText(/Type to search across all/i)).toBeInTheDocument();
+    });
+
+    test('matches a chapter by title and selects it', () => {
+        const onSelectResult = jest.fn();
+        const onClose = jest.fn();
+        render(<ChapterSearch onSelectResult={onSelectResult} onClose={onClose} />);
+
+        const module = learningModules[0];
+        const chapter = module.chapters[0];
+        fireEvent.change(screen.getByPlaceholderText(/Search chapters/i), {
+            target: { value: chapter.title },
+        });
+
+        const heading = screen.getByRole('heading', { name: chapter.title });
+        fireEvent.click(heading.closest('button'));
+
+        expect(onSelectResult).toHaveBeenCalledWith(module, chapter);
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    test('shows a no-results message for an unmatched query', () => {
+        render(<ChapterSearch onSelectResult={jest.fn()} onClose={jest.fn()} />);
+        fireEvent.change(screen.getByPlaceholderText(/Search chapters/i), {
+            target: { value: 'zzz-nonexistent-query-xyz' },
+        });
+        expect(screen.getByText(/No results found/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/getting-started/KeyboardHelp.test.js
+++ b/frontend/src/components/getting-started/KeyboardHelp.test.js
@@ -1,0 +1,17 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import KeyboardHelp from './KeyboardHelp';
+
+describe('KeyboardHelp', () => {
+    test('lists the shortcuts and closes via the button', () => {
+        const onClose = jest.fn();
+        render(<KeyboardHelp onClose={onClose} />);
+
+        expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+        expect(screen.getByText('Previous chapter')).toBeInTheDocument();
+        expect(screen.getByText('Mark chapter complete')).toBeInTheDocument();
+        expect(screen.getByText('Open search')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/components/getting-started/QuizSection.test.js
+++ b/frontend/src/components/getting-started/QuizSection.test.js
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import QuizSection from './QuizSection';
+
+describe('QuizSection', () => {
+    test('opens on the difficulty picker', () => {
+        render(<QuizSection />);
+        expect(screen.getByText('Test Your Market Knowledge')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /easy/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /medium/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /hard/i })).toBeInTheDocument();
+    });
+
+    test('starting a quiz shows the first question with the advance button disabled', () => {
+        render(<QuizSection />);
+        fireEvent.click(screen.getByRole('button', { name: /easy/i }));
+
+        expect(screen.getByText(/Question 1 of/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Next Question|Finish Quiz/i })).toBeDisabled();
+    });
+});


### PR DESCRIPTION
9 render tests across the learning-center components — KeyboardHelp, ChapterSearch (real content-data search), ChapterContent (all block types + complete toggle), QuizSection (difficulty picker + quiz start). Verified via full `run_frontend_checks.sh` (208 tests / 43 suites, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)