### PR TITLE
test: cover landing components (lock-in)

### DIFF
--- a/frontend/src/components/landing/DashboardPreview.test.js
+++ b/frontend/src/components/landing/DashboardPreview.test.js
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import DashboardPreview from './DashboardPreview';
+
+describe('DashboardPreview', () => {
+    test('renders the mock dashboard sections', () => {
+        render(<DashboardPreview />);
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+        expect(screen.getByText(/AI Forecast/)).toBeInTheDocument();
+        expect(screen.getByText('Paper Portfolio')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/landing/MarqueeTicker.test.js
+++ b/frontend/src/components/landing/MarqueeTicker.test.js
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import MarqueeTicker from './MarqueeTicker';
+
+describe('MarqueeTicker', () => {
+    test('renders the live badge and mock ticker items after mount', () => {
+        render(<MarqueeTicker />);
+        expect(screen.getByText('Live')).toBeInTheDocument();
+        // Items are duplicated for the seamless marquee loop.
+        expect(screen.getAllByText('S&P 500').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('AAPL').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('BTC').length).toBeGreaterThan(0);
+    });
+});

--- a/frontend/src/components/landing/StepTerminals.test.js
+++ b/frontend/src/components/landing/StepTerminals.test.js
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import StepTerminals from './StepTerminals';
+
+// framer-motion's whileInView relies on IntersectionObserver (absent in jsdom),
+// and the terminal typer runs timers; stub the observer and use fake timers so
+// the static content renders deterministically.
+beforeAll(() => {
+    global.IntersectionObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+});
+
+beforeEach(() => {
+    jest.useFakeTimers();
+});
+
+afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+});
+
+describe('StepTerminals', () => {
+    test('renders the three how-it-works step titles', () => {
+        render(<StepTerminals />);
+        expect(screen.getByText('Search Any Asset')).toBeInTheDocument();
+        expect(screen.getByText('Analyze the AI Forecast')).toBeInTheDocument();
+        expect(screen.getByText('Trade Risk-Free')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Smoke tests for MarqueeTicker, StepTerminals, and DashboardPreview (framer-motion stubbed). **Completes direct test coverage of every extracted component folder.** Verified via full `run_frontend_checks.sh` (219 tests / 48 suites, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)