### PR TITLE
feat: authorization Principal + capability model (access-control A0+A1)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -147,6 +147,7 @@ except (AttributeError, ValueError):
 # --- New Imports for Options Suggester ---
 from options_suggester import generate_suggestion
 import api_auth as api_auth_helpers
+import authz
 import api_handlers_deliverables as deliverables_handlers
 import api_handlers_market_data as market_data_handlers
 import api_handlers_marketmind_ai as marketmind_ai_handlers
@@ -489,6 +490,11 @@ def get_current_user_id():
     return getattr(g, 'current_user_id', None)
 
 
+def get_current_principal():
+    """The authorization Principal for the current request (None if unauthenticated)."""
+    return getattr(g, 'principal', None)
+
+
 def require_auth(f):
     return api_auth_helpers.build_require_auth(
         f,
@@ -499,6 +505,10 @@ def require_auth(f):
         set_request_identity_fn=lambda payload: (
             setattr(g, 'current_user_id', payload['sub']),
             setattr(g, 'auth_payload', payload),
+            # Authorization Principal (phase A1): informational for now — routes
+            # begin asserting capabilities in a later phase. Every user gets the
+            # base ``user`` role, so this is behavior-preserving.
+            setattr(g, 'principal', authz.principal_for_user(payload['sub'], payload)),
         ),
     )
 

--- a/backend/authz.py
+++ b/backend/authz.py
@@ -1,0 +1,146 @@
+"""Authorization layer: principals, roles, and capabilities.
+
+Authentication (``api_auth.py``) answers *who are you*; this module answers *what
+may you do*. A :class:`Principal` carries the acting identity plus the set of
+capabilities it holds, resolved from its roles.
+
+Phase A1 (this module) is deliberately **behavior-preserving**: every
+authenticated user is granted the ``user`` role, which holds every non-admin
+capability, so nothing is denied until routes begin asserting specific
+capabilities (phase A2). The ``g.principal`` set during auth is informational
+here — no route reads it for authorization yet.
+
+Capability naming is ``<domain>.<action>`` and stable; the A0 route→capability
+map (applied in A2) is:
+
+    /auth/me                         -> account.read
+    /deliverables (GET)              -> deliverables.read
+    /deliverables (POST/PATCH/PUT/…) -> deliverables.write
+    /marketmind-ai/* (GET)           -> ai.read
+    /marketmind-ai/* (POST/DELETE)   -> ai.write
+    /watchlist (GET)                 -> watchlist.read
+    /watchlist/<t> (POST/DELETE)     -> watchlist.write
+    /paper/{portfolio,history,transactions} (GET) -> paper.read
+    /paper/{buy,sell,options/*,optimize,reset}    -> paper.trade
+    /notifications (GET)             -> notifications.read
+    /notifications (POST/DELETE)     -> notifications.write
+    /prediction-markets/{portfolio,history} (GET) -> prediction_markets.read
+    /prediction-markets/{analyze,buy,sell,reset}  -> prediction_markets.trade
+    (public-API admin surface)       -> admin.public_api   (admin role only)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Iterable, Optional
+
+
+class Capabilities:
+    """Stable capability identifiers, one per (domain, action)."""
+
+    ACCOUNT_READ = "account.read"
+    DELIVERABLES_READ = "deliverables.read"
+    DELIVERABLES_WRITE = "deliverables.write"
+    AI_READ = "ai.read"
+    AI_WRITE = "ai.write"
+    WATCHLIST_READ = "watchlist.read"
+    WATCHLIST_WRITE = "watchlist.write"
+    PAPER_READ = "paper.read"
+    PAPER_TRADE = "paper.trade"
+    NOTIFICATIONS_READ = "notifications.read"
+    NOTIFICATIONS_WRITE = "notifications.write"
+    PREDICTION_MARKETS_READ = "prediction_markets.read"
+    PREDICTION_MARKETS_TRADE = "prediction_markets.trade"
+    # Admin-only.
+    ADMIN_PUBLIC_API = "admin.public_api"
+
+
+# Everything a normal signed-in user can do today (full app access). Admin-only
+# capabilities are intentionally excluded.
+USER_CAPABILITIES: FrozenSet[str] = frozenset(
+    {
+        Capabilities.ACCOUNT_READ,
+        Capabilities.DELIVERABLES_READ,
+        Capabilities.DELIVERABLES_WRITE,
+        Capabilities.AI_READ,
+        Capabilities.AI_WRITE,
+        Capabilities.WATCHLIST_READ,
+        Capabilities.WATCHLIST_WRITE,
+        Capabilities.PAPER_READ,
+        Capabilities.PAPER_TRADE,
+        Capabilities.NOTIFICATIONS_READ,
+        Capabilities.NOTIFICATIONS_WRITE,
+        Capabilities.PREDICTION_MARKETS_READ,
+        Capabilities.PREDICTION_MARKETS_TRADE,
+    }
+)
+
+ADMIN_CAPABILITIES: FrozenSet[str] = USER_CAPABILITIES | frozenset(
+    {Capabilities.ADMIN_PUBLIC_API}
+)
+
+# Roles are named bundles of capabilities. Code-defined for now; a later phase
+# may source assignments from Clerk / a local table.
+ROLES: Dict[str, FrozenSet[str]] = {
+    "user": USER_CAPABILITIES,
+    "admin": ADMIN_CAPABILITIES,
+}
+
+DEFAULT_ROLE = "user"
+
+# The full set of known capabilities (union across all roles).
+ALL_CAPABILITIES: FrozenSet[str] = frozenset().union(*ROLES.values())
+
+
+@dataclass(frozen=True)
+class Principal:
+    """The acting identity plus the capabilities it holds."""
+
+    id: str
+    kind: str = "user"  # "user" | "api_key"
+    roles: FrozenSet[str] = field(default_factory=lambda: frozenset({DEFAULT_ROLE}))
+    capabilities: FrozenSet[str] = field(default_factory=frozenset)
+    claims: Dict[str, Any] = field(default_factory=dict)
+
+    def has(self, capability: str) -> bool:
+        return capability in self.capabilities
+
+    def has_any(self, capabilities: Iterable[str]) -> bool:
+        return any(c in self.capabilities for c in capabilities)
+
+
+def capabilities_for_roles(roles: Iterable[str]) -> FrozenSet[str]:
+    caps: set = set()
+    for role in roles:
+        caps |= ROLES.get(role, frozenset())
+    return frozenset(caps)
+
+
+def roles_from_claims(claims: Optional[Dict[str, Any]]) -> FrozenSet[str]:
+    """Resolve roles from Clerk claims, always including the base ``user`` role.
+
+    Clerk can expose roles via ``publicMetadata.roles`` (or a top-level ``roles``
+    claim). Unknown role names are ignored. Until admins are provisioned (phase
+    A3) this yields ``{"user"}`` for everyone, preserving today's access.
+    """
+    claims = claims or {}
+    raw = (claims.get("publicMetadata") or {}).get("roles")
+    if raw is None:
+        raw = claims.get("roles")
+    if isinstance(raw, str):
+        raw = [raw]
+    roles = {str(r).strip().lower() for r in (raw or []) if str(r).strip()}
+    roles &= set(ROLES)  # drop anything not in the role registry
+    roles.add(DEFAULT_ROLE)  # everyone is at least a user
+    return frozenset(roles)
+
+
+def principal_for_user(user_id: str, claims: Optional[Dict[str, Any]] = None) -> Principal:
+    """Build a Principal for a Clerk-authenticated user from its token claims."""
+    roles = roles_from_claims(claims)
+    return Principal(
+        id=user_id,
+        kind="user",
+        roles=roles,
+        capabilities=capabilities_for_roles(roles),
+        claims=claims or {},
+    )

--- a/backend/run_deterministic_backend_checks.sh
+++ b/backend/run_deterministic_backend_checks.sh
@@ -45,6 +45,7 @@ fi
   backend.tests.test_app_factory \
   backend.tests.test_asset_identity \
   backend.tests.test_auth_isolation \
+  backend.tests.test_authz \
   backend.tests.test_backfill_postgres \
   backend.tests.test_chart_prediction_append \
   backend.tests.test_deliverables_api \

--- a/backend/tests/test_authz.py
+++ b/backend/tests/test_authz.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import authz
+from authz import Capabilities, Principal
+
+
+class AuthzModelTests(unittest.TestCase):
+    def test_user_role_holds_every_non_admin_capability(self):
+        # Behavior-preservation anchor: a normal signed-in user must retain full
+        # app access, i.e. every capability except the admin-only ones.
+        user_caps = authz.capabilities_for_roles(["user"])
+        self.assertEqual(user_caps, authz.USER_CAPABILITIES)
+        self.assertNotIn(Capabilities.ADMIN_PUBLIC_API, user_caps)
+        # Every capability a route could assert (all user caps) is granted.
+        for cap in authz.USER_CAPABILITIES:
+            self.assertIn(cap, user_caps)
+
+    def test_admin_role_adds_admin_capabilities_on_top_of_user(self):
+        admin_caps = authz.capabilities_for_roles(["admin"])
+        self.assertTrue(authz.USER_CAPABILITIES <= admin_caps)
+        self.assertIn(Capabilities.ADMIN_PUBLIC_API, admin_caps)
+
+    def test_unknown_role_contributes_nothing(self):
+        self.assertEqual(authz.capabilities_for_roles(["nope"]), frozenset())
+
+    def test_roles_from_claims_defaults_everyone_to_user(self):
+        self.assertEqual(authz.roles_from_claims(None), frozenset({"user"}))
+        self.assertEqual(authz.roles_from_claims({}), frozenset({"user"}))
+
+    def test_roles_from_claims_reads_public_metadata_and_top_level(self):
+        self.assertEqual(
+            authz.roles_from_claims({"publicMetadata": {"roles": ["admin"]}}),
+            frozenset({"user", "admin"}),
+        )
+        self.assertEqual(
+            authz.roles_from_claims({"roles": "admin"}),
+            frozenset({"user", "admin"}),
+        )
+
+    def test_roles_from_claims_ignores_unknown_roles(self):
+        self.assertEqual(
+            authz.roles_from_claims({"roles": ["superuser", "admin"]}),
+            frozenset({"user", "admin"}),
+        )
+
+    def test_principal_for_user_defaults_to_full_user_access(self):
+        principal = authz.principal_for_user("user_123", {"sub": "user_123"})
+        self.assertEqual(principal.id, "user_123")
+        self.assertEqual(principal.kind, "user")
+        self.assertEqual(principal.roles, frozenset({"user"}))
+        self.assertEqual(principal.capabilities, authz.USER_CAPABILITIES)
+        self.assertTrue(principal.has(Capabilities.PAPER_TRADE))
+        self.assertFalse(principal.has(Capabilities.ADMIN_PUBLIC_API))
+
+    def test_principal_for_admin_user_from_claims(self):
+        principal = authz.principal_for_user(
+            "user_admin", {"sub": "user_admin", "publicMetadata": {"roles": ["admin"]}}
+        )
+        self.assertIn("admin", principal.roles)
+        self.assertTrue(principal.has(Capabilities.ADMIN_PUBLIC_API))
+
+    def test_principal_has_any(self):
+        principal = Principal(
+            id="u", capabilities=frozenset({Capabilities.WATCHLIST_READ})
+        )
+        self.assertTrue(principal.has_any([Capabilities.WATCHLIST_READ, "other"]))
+        self.assertFalse(principal.has_any(["a", "b"]))
+
+
+class ApiPrincipalWiringTests(unittest.TestCase):
+    def test_api_exposes_get_current_principal_and_sets_it_on_auth(self):
+        import api as backend_api
+
+        # The helper exists and returns None outside a request context.
+        self.assertTrue(hasattr(backend_api, "get_current_principal"))
+        # A default user principal grants full user access (behavior-preserving).
+        principal = backend_api.authz.principal_for_user("u1", {"sub": "u1"})
+        self.assertEqual(principal.capabilities, authz.USER_CAPABILITIES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First, **behavior-preserving** step of the access-control redesign (see the scope doc).

- **authz.py**: a `Principal` (identity + capabilities) with capabilities as the primitive and roles as named bundles — `user` = every non-admin capability, `admin` = user + `admin.public_api`.
- **A0**: each of the 47 auth-gated routes mapped to a stable `<domain>.<action>` capability (documented in authz.py).
- **A1**: `require_auth` attaches `g.principal` via the existing DI seam; `get_current_principal()` added; roles resolve from Clerk claims, defaulting everyone to `user`.

Behavior-preserving: `user` holds every non-admin capability and nothing reads `g.principal` for authz yet (routes assert capabilities in A2), so all existing routes behave identically. `import api` stays ML-free. Verified: ruff clean + full suite **161 tests OK** (+10 authz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)